### PR TITLE
Use a warning if a remote bam file has no index.

### DIFF
--- a/pysam/csamtools.pyx
+++ b/pysam/csamtools.pyx
@@ -874,7 +874,7 @@ cdef class Samfile:
             else:
                 self.index = bam_index_load(filename)
                 if self.index == NULL:
-                    raise IOError("error while opening index `%s` " % filename )
+                    warnings.warn("unable to open index for `%s` " % filename)
 
             if not self.isstream:
                 self.start_offset = bam_tell( self.samfile.x.bam )


### PR DESCRIPTION
Hi,

I was trying to curate some ENCODE3 data on a data warehouse that only had the .bam files and not the .bai files. Since I just needed to read the header and a few reads, I could avoid the samtools functionality that needs the index.

So I changed the exception to a warning. Do you think it would be reasonable to incorporate this patch?

Diane
