### PR TITLE
Update usage.rst

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -43,7 +43,8 @@ Using a function object, work can be done on the alignments. The
 code below simply counts aligned reads::
 
    class Counter:
-       cCounts = 0
+       def __init__(self):
+           self.counts = 0
        def __call__(self, alignment):
            self.counts += 1
    


### PR DESCRIPTION
The code example involving the "Counter" class results in error on python3. This change would fix it.
