### PR TITLE
Minor cleanups

### DIFF
--- a/pysam/chtslib.pxd
+++ b/pysam/chtslib.pxd
@@ -40,10 +40,10 @@ cdef extern from "stdio.h":
 cdef extern from "ctype.h":
   int toupper(int c)
   int tolower(int c)
-  
+
 cdef extern from "unistd.h":
   char *ttyname(int fd)
-  int isatty(int fd)  
+  int isatty(int fd)
 
 cdef extern from "string.h":
   int strcmp(char *s1, char *s2)
@@ -98,9 +98,6 @@ cdef extern from "pysam_stream.h":
 
     kstream_t * ks_init(gzFile)
     int ks_getuntil(kstream_t *, int delimiter, kstring_t str, int * dret)
-
-from libc.stdint cimport int8_t, int16_t, int32_t, int64_t
-from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t
 
 cdef extern from "htslib/kstring.h" nogil:
     ctypedef struct kstring_t:
@@ -329,7 +326,7 @@ cdef extern from "htslib/hts.h" nogil:
         cram_fd * cram
         hFILE * hfile
         void * voidp
-      
+
     ctypedef struct htsFile:
 	# uint32_t is_bin:1, is_write:1, is_be:1, is_cram:1, is_compressed:2, is_kstream:1, dummy:25;
         uint32_t  is_bin
@@ -458,7 +455,7 @@ cdef extern from "htslib/hts.h" nogil:
         int beg,
         int end,
         hts_readrec_func *readrec)
-    
+
     hts_itr_t *hts_itr_querys(
         const hts_idx_t *idx,
         const char *reg,
@@ -614,7 +611,7 @@ cdef extern from "htslib/sam.h" nogil:
     # 2. l_qseq is calculated from the total length of an alignment block
     # on reading or from CIGAR.
     # 3. cigar data is encoded 4 bytes per CIGAR operation.
-    # 4. seq is nybble-encoded according to bam_nt16_table.
+    # 4. seq is nybble-encoded according to seq_nt16_table.
     ctypedef struct bam1_t:
         bam1_core_t core
         int l_data, m_data
@@ -855,7 +852,7 @@ cdef extern from "htslib/faidx.h":
    int faidx_fetch_nseq(faidx_t *fai)
 
    char *faidx_fetch_seq(faidx_t *fai,
-                         char *c_name, 
+                         char *c_name,
                          int p_beg_i,
                          int p_end_i,
                          int *len)
@@ -863,7 +860,7 @@ cdef extern from "htslib/faidx.h":
 cdef extern from "htslib_util.h":
 
     # add *nbytes* into the variable length data of *src* at *pos*
-    bam1_t * pysam_bam_update( bam1_t * b, 
+    bam1_t * pysam_bam_update( bam1_t * b,
                                size_t nbytes_old,
                                size_t nbytes_new,
                                uint8_t * pos )
@@ -923,7 +920,7 @@ cdef class FastqProxy:
 cdef class Fastqfile:
     cdef object _filename
     cdef gzFile fastqfile
-    cdef kseq_t * entry 
+    cdef kseq_t * entry
 
     cdef kseq_t * getCurrent( self )
     cdef int cnext(self)
@@ -933,7 +930,7 @@ cdef class AlignedRead:
     # object that this AlignedRead represents
     cdef bam1_t * _delegate
 
-    # add an alignment tag with value to the AlignedRead 
+    # add an alignment tag with value to the AlignedRead
     # an existing tag of the same name will be replaced.
     cpdef setTag( self, tag, value, value_type = ?, replace = ? )
 
@@ -963,7 +960,7 @@ cdef class Samfile:
     cdef char * mode
 
     # beginning of read section
-    cdef int64_t start_offset 
+    cdef int64_t start_offset
 
     cdef bam_hdr_t * _buildHeader(self, new_header)
     cdef bam1_t * getCurrent(self)
@@ -1063,5 +1060,3 @@ cdef class IndexedReads:
     cdef index
     # true if samfile belongs to this object
     cdef int owns_samfile
-
-

--- a/pysam/chtslib.pyx
+++ b/pysam/chtslib.pyx
@@ -89,58 +89,11 @@ cdef _forceStr(object s):
 ########################################################################
 ## Constants and global variables
 ########################################################################
-DEF HTS_FMT_CSI = 0
-DEF HTS_FMT_BAI = 1
-DEF HTS_FMT_TBI = 2
-DEF HTS_FMT_CRAI = 3
 
 # defines imported from samtools
 DEF SEEK_SET = 0
 DEF SEEK_CUR = 1
 DEF SEEK_END = 2
-
-## These are bits set in the flag.
-## have to put these definitions here, in csamtools.pxd they got ignored
-## @abstract the read is paired in sequencing, no matter whether it is mapped in a pair
-DEF BAM_FPAIRED       =1
-## @abstract the read is mapped in a proper pair
-DEF BAM_FPROPER_PAIR  =2
-## @abstract the read itself is unmapped; conflictive with BAM_FPROPER_PAIR
-DEF BAM_FUNMAP        =4
-## @abstract the mate is unmapped
-DEF BAM_FMUNMAP       =8
-## @abstract the read is mapped to the reverse strand
-DEF BAM_FREVERSE      =16
-## @abstract the mate is mapped to the reverse strand
-DEF BAM_FMREVERSE     =32
-## @abstract this is read1
-DEF BAM_FREAD1        =64
-## @abstract this is read2
-DEF BAM_FREAD2       =128
-## @abstract not primary alignment
-DEF BAM_FSECONDARY   =256
-## @abstract QC failure
-DEF BAM_FQCFAIL      =512
-## @abstract optical or PCR duplicate
-DEF BAM_FDUP        =1024
-## @abstract supplementary alignment
-DEF BAM_FSUPPLEMENTARY =2048
-
-#####################################################################
-# CIGAR operations
-DEF BAM_CIGAR_SHIFT=4
-DEF BAM_CIGAR_MASK=((1 << BAM_CIGAR_SHIFT) - 1)
-
-DEF BAM_CMATCH     = 0
-DEF BAM_CINS       = 1
-DEF BAM_CDEL       = 2
-DEF BAM_CREF_SKIP  = 3
-DEF BAM_CSOFT_CLIP = 4
-DEF BAM_CHARD_CLIP = 5
-DEF BAM_CPAD       = 6
-DEF BAM_CEQUAL     = 7
-DEF BAM_CDIFF      = 8
-
 
 cdef char* CODE2CIGAR= "MIDNSHP=X"
 if IS_PYTHON3:
@@ -151,7 +104,6 @@ CIGAR_REGEX = re.compile( "(\d+)([MIDNSHP=X])" )
 
 #####################################################################
 # hard-coded constants
-cdef char * bam_nt16_rev_table = "=ACMGRSVTWYHKDBN"
 cdef int max_pos = 2 << 29
 
 #####################################################################
@@ -408,7 +360,7 @@ cdef class Fastafile:
         if not region:
             if reference is None: raise ValueError( 'no sequence/region supplied.' )
             if start is None: start = 0
-            if end is None: end = max_pos -1
+            if end is None: end = max_pos - 1
 
             if start > end: raise ValueError( 'invalid region: start (%i) > end (%i)' % (start, end) )
             if start == end: return b""
@@ -2198,9 +2150,9 @@ cdef inline object get_seq_range(bam1_t *src, uint32_t start, uint32_t end):
     p   = pysam_bam_get_seq(src)
 
     for k from start <= k < end:
-        # equivalent to bam_nt16_rev_table[bam1_seqi(s, i)] (see bam.c)
+        # equivalent to seq_nt16_str[bam1_seqi(s, i)] (see bam.c)
         # note: do not use string literal as it will be a python string
-        s[k-start] = bam_nt16_rev_table[p[k/2] >> 4 * (1 - k%2) & 0xf]
+        s[k-start] = seq_nt16_str[p[k/2] >> 4 * (1 - k%2) & 0xf]
 
     return seq
 
@@ -3773,7 +3725,7 @@ cdef class SNPCall:
 
 #        g = bam_maqcns_glfgen( self.iter.n_plp,
 #                               self.iter.plp,
-#                               bam_nt16_table[rb],
+#                               seq_nt16_table[rb],
 #                               self.c )
 
 #        if pysam_glf_depth( g ) == 0:
@@ -3789,7 +3741,7 @@ cdef class SNPCall:
 #         call._tid = self.iter.tid
 #         call._pos = self.iter.pos
 #         call._reference_base = rb
-#         call._genotype = bam_nt16_rev_table[cns>>28]
+#         call._genotype = seq_nt16_str[cns>>28]
 #         call._consensus_quality = cns >> 8 & 0xff
 #         call._snp_quality = cns & 0xff
 #         call._rms_mapping_quality = cns >> 16&0xff
@@ -3854,7 +3806,7 @@ cdef class SNPCall:
 # #
 # #        g = bam_maqcns_glfgen( self.iter.n_plp,
 # #                               self.iter.plp,
-# #                               bam_nt16_table[rb],
+# #                               seq_nt16_table[rb],
 # #                               self.c )
 # ##
 # #
@@ -3871,7 +3823,7 @@ cdef class SNPCall:
 #         call._tid = self.iter.tid
 #         call._pos = self.iter.pos
 #         call._reference_base = rb
-#         call._genotype = bam_nt16_rev_table[cns>>28]
+#         call._genotype = seq_nt16_str[cns>>28]
 #         call._consensus_quality = cns >> 8 & 0xff
 #         call._snp_quality = cns & 0xff
 #         call._rms_mapping_quality = cns >> 16&0xff


### PR DESCRIPTION
Details:
1. removed redundant definitions (`HTS_FMT_*`, `BAM_*`)
2. replaced `bam_nt16_table` with `seq_nt16_table`
3. replaced `bam_nt16_rev_table` with `seq_nt16_str`
