### PR TITLE
Added new read property: is_supplementary (sam flag 0x800)

### DIFF
--- a/pysam/calignmentfile.pyx
+++ b/pysam/calignmentfile.pyx
@@ -2753,6 +2753,13 @@ cdef class AlignedSegment:
             return (self.flag & BAM_FDUP) != 0
         def __set__(self, val):
             pysam_update_flag(self._delegate, val, BAM_FDUP)
+    property is_supplementary:
+        """true if secondary alignment"""
+        def __get__(self):
+            return (self.flag & BAM_FSUPPLEMENTARY) != 0
+        def __set__(self, val):
+            pysam_update_flag(self._delegate, val, BAM_FSUPPLEMENTARY)
+
 
     # 2. Coordinates and lengths
     property reference_end:

--- a/save/pysam_test2.6.py
+++ b/save/pysam_test2.6.py
@@ -993,7 +993,7 @@ class TestAlignedRead(unittest.TestCase):
                   "is_reverse", "mate_is_reverse",
                   "is_read1", "is_read2",
                   "is_secondary", "is_qcfail",
-                  "is_duplicate", "bin"):
+                  "is_duplicate", "is_supplementary", "bin"):
             if x in exclude: continue
             self.assertEqual( getattr(read1, x), getattr(read2,x), "attribute mismatch for %s: %s != %s" % 
                               (x, getattr(read1, x), getattr(read2,x)))
@@ -1070,7 +1070,7 @@ class TestAlignedRead(unittest.TestCase):
             "is_reverse", "mate_is_reverse",
             "is_read1", "is_read2",
             "is_secondary", "is_qcfail",
-            "is_duplicate"):
+            "is_duplicate", "is_supplementary"):
             setattr( b, x, True )
             self.assertEqual( getattr(b, x), True )
             self.checkFieldEqual( a, b, ("flag", x,) )
@@ -1170,7 +1170,7 @@ class TestDeNovoConstruction(unittest.TestCase):
                   "is_reverse", "mate_is_reverse",
                   "is_read1", "is_read2",
                   "is_secondary", "is_qcfail",
-                  "is_duplicate"):
+                  "is_duplicate", "is_supplementary"):
             if x in exclude: continue
             self.assertEqual( getattr(read1, x), getattr(read2,x), "attribute mismatch for %s: %s != %s" % 
                               (x, getattr(read1, x), getattr(read2,x)))

--- a/tests/AlignmentFile_test.py
+++ b/tests/AlignmentFile_test.py
@@ -1186,7 +1186,7 @@ class ReadTest(unittest.TestCase):
                   ".is_reverse", ".mate_is_reverse",
                   ".is_read1", ".is_read2",
                   ".is_secondary", ".is_qcfail",
-                  ".is_duplicate"):
+                  ".is_duplicate", ".is_supplementary"):
             n = x[1:]
             if n in exclude:
                 continue
@@ -1284,7 +1284,7 @@ class TestAlignedSegment(ReadTest):
                 "is_reverse", "mate_is_reverse",
                 "is_read1", "is_read2",
                 "is_secondary", "is_qcfail",
-                "is_duplicate"):
+                "is_duplicate", "is_supplementary"):
             setattr(b, x, True)
             self.assertEqual(getattr(b, x), True)
             self.checkFieldEqual(a, b, ("flag", x,))

--- a/tests/pysam_test.py
+++ b/tests/pysam_test.py
@@ -1172,7 +1172,7 @@ class ReadTest(unittest.TestCase):
                   ".is_reverse", ".mate_is_reverse",
                   ".is_read1", ".is_read2",
                   ".is_secondary", ".is_qcfail",
-                  ".is_duplicate"):
+                  ".is_duplicate", ".is_supplementary"):
             n = x[1:]
             if n in exclude:
                 continue
@@ -1268,7 +1268,7 @@ class TestAlignedRead(ReadTest):
                 "is_reverse", "mate_is_reverse",
                 "is_read1", "is_read2",
                 "is_secondary", "is_qcfail",
-                "is_duplicate"):
+                "is_duplicate", "is_supplementary"):
             setattr(b, x, True)
             self.assertEqual(getattr(b, x), True)
             self.checkFieldEqual(a, b, ("flag", x,))


### PR DESCRIPTION
Added new read property: is_supplementary (sam flag 0x800). From the SAM spec: "Bit 0x800 indicates that the corresponding alignment line is part of a chimeric alignment. A line flagged with 0x800 is called as a supplementary line."
