### PR TITLE
Installation should not require Cython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -447,7 +447,6 @@ metadata = {
                     cvcf,
                     faidx],
     'cmdclass': cmdclass,
-    'install_requires': ['cython>=0.20.1', ],
     'package_dir': {'pysam': 'pysam',
                     'pysam.include.htslib': 'htslib',
                     'pysam.include.samtools': 'samtools'},


### PR DESCRIPTION
pysam already follows the recommendation by Cython developers not to
require Cython to be installed and to instead distribute the compiled C
files, as recommended here:
http://docs.cython.org/src/reference/compilation.html#distributing-cython-modules

Currently, since an install_requires directive containing Cython is passed
to setup(), Cython will always be installed when running 'python setup.py
install' or 'pip install pysam'. This commit removes 'install_requires'.

In fact, the code as it was does not even work anyway: When running `python setup.py install`, Cython is installed _after_ pysam itself. It should probably have been `setup_requires` or so.
