### PR TITLE
Do not attempt to import ez_setup since it does not exist.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -215,12 +215,7 @@ if len(sys.argv) == 2 and sys.argv[1] == "htslib":
 # cp samtools/*.h pysam/*.h pysam/include
 # cp samtools/win32/*.h pysam/include/win32
 
-try:
-    from setuptools import Extension, setup
-except ImportError:
-    from ez_setup import use_setuptools
-    use_setuptools()
-    from setuptools import Extension, setup
+from setuptools import Extension, setup
 
 #######################################################
 #######################################################


### PR DESCRIPTION
Since the switch from distribute to setuptools, an attempt is made to import `ez_setup`, but that file does not exist.

Alternatively, ez_setup.py could be added to the distribution, but it appears
no one has ever complained about it not being there. Probably most people
have setuptools installed already, so just rely on that.
