### PR TITLE
Example `pysam.AlignedSegment` needs fixing under `v0.8.1`

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -118,7 +118,7 @@ Here, we use a header dictionary::
    a.next_reference_id = 0
    a.next_reference_start=199
    a.template_length=167
-   a.query_qualities="<<<<<<<<<<<<<<<<<<<<<:<9/,&,22;;<<<"
+   a.query_qualities = pysam.fromQualityString("<<<<<<<<<<<<<<<<<<<<<:<9/,&,22;;<<<")
    a.tags = (("NM", 1),
 	     ("RG", "L1"))
    outfile.write(a)


### PR DESCRIPTION
The example in the docs of creating a `pysam.AlignedSegment` no longer works under `v0.8.1`.This is because the `query_qualities` can no longer be set as a string.

I'm not sure what the preferred approach is for setting the `query_qualities`. I am using `pysam.fromQualityString()` but it could equally be hand-coded using `array.array()` with the type set to `B`.