### PR TITLE
Updates docs to reflect htslib 1.2.1

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,7 +15,7 @@ in *SAM/BAM* formatted files. Also included is an interface to the
 samtools_ command line utilities and the tabix_ C-API for reading
 compressed and indexed tabular data.
 
-The current version wraps *htslib-1.1* and *samtools-1.1*.
+The current version wraps *htslib-1.2.1* and *samtools-1.2*.
 
 Contents
 --------


### PR DESCRIPTION
The current version of pysam (0.8.2) has already been updated to htslib 1.2.1, but the docs still say it wrap htslib 1.1. This updates the dos to reflect that reality.