### PR TITLE
Straw-man implementation of hts_verbose access.

### DIFF
--- a/pysam/cbcf.pyx
+++ b/pysam/cbcf.pyx
@@ -196,7 +196,19 @@ from cpython cimport PyBytes_Check, PyUnicode_Check
 from cpython.version cimport PY_MAJOR_VERSION
 
 
-__all__ = ['VariantFile', 'VariantHeader']
+__all__ = ['VariantFile', 'VariantHeader', 'set_hts_verbose', 'get_hts_verbose']
+
+
+
+def set_hts_verbose(int verbosity):
+    u"""Set htslib's hts_verbose global variable to the specified value.
+    """
+    cdef extern int hts_verbose = verbosity
+
+def get_hts_verbose():
+    u"""Return the value of htslib's hts_verbose global variable.
+    """
+    return hts_verbose
 
 
 ########################################################################


### PR DESCRIPTION
This is a straw-man partial implementation of providing access to `hts_verbose`, so we can control when messages are written to the low-level file descriptors. (See issue #88).

Problems with this PR:

1. It doesn't work. I haven't been able to figure out how to get the linkage for the extern hts_verbose variable to work. It remains set to 3 no matter what I do. If this is a genuine problem (and not just my Cython idiocy), perhaps we should open an issue with htslib where they provide functions to get and set the verbosity instead of requiring us to use a global variable?
2. This is in the wrong file. I think this functionality probably belongs in `chtslib.pyx`, but I couldn't get the compiler to see `hts_verbose` if  I put it in there. 

I'm new to Cython, so any pointers would be much appreciated!