### PR TITLE
Almost all CIGAR and optional matches_only for read.get_aligned_pairs()

### DIFF
--- a/pysam/calignmentfile.pyx
+++ b/pysam/calignmentfile.pyx
@@ -2969,8 +2969,14 @@ cdef class AlignedSegment:
 
         return qpos
             
-    def get_aligned_pairs(self):
-        """a list of aligned read and reference positions.
+    def get_aligned_pairs(self, matches_only = False):
+        """a list of aligned read (query) and reference positions.
+        For inserts, deletions, skipping either query or reference position may be None.
+
+        If @matches_only is True, only matched bases are returned - no None on either side.
+
+        Padding is currently not supported and leads to an exception
+        
         """
         cdef uint32_t k, i, pos, qpos
         cdef int op
@@ -2990,21 +2996,31 @@ cdef class AlignedSegment:
             op = cigar_p[k] & BAM_CIGAR_MASK
             l = cigar_p[k] >> BAM_CIGAR_SHIFT
 
-            if op == BAM_CMATCH:
+            if op == BAM_CMATCH or op == BAM_CEQUAL or op == BAM_CDIFF:
                 for i from pos <= i < pos + l:
                     result.append((qpos, i))
                     qpos += 1
                 pos += l
 
-            elif op == BAM_CINS:
-                for i from pos <= i < pos + l:
-                    result.append((qpos, None))
-                    qpos += 1
+            elif op == BAM_CINS or op == BAM_CSOFT_CLIP:
+                if not matches_only:
+                    for i from pos <= i < pos + l:
+                        result.append((qpos, None))
+                        qpos += 1
+                else:
+                    qpos += l
 
             elif op == BAM_CDEL or op == BAM_CREF_SKIP:
-                for i from pos <= i < pos + l:
-                    result.append((None, i))
+                if not matches_only:
+                    for i from pos <= i < pos + l:
+                        result.append((None, i))
                 pos += l
+
+            elif op == BAM_CHARD_CLIP:
+                pass # advances neither
+
+            elif op == BAM_CPAD:
+                raise NotImplementedError("Padding (BAM_CPAD, 6) is currently not supported. Please implement. Sorry about that.")
 
         return result
 

--- a/pysam/calignmentfile.pyx
+++ b/pysam/calignmentfile.pyx
@@ -2982,6 +2982,9 @@ cdef class AlignedSegment:
         cdef int op
         cdef uint32_t * cigar_p
         cdef bam1_t * src 
+        cdef int _matches_only
+
+        _matches_only = bool(matches_only)
 
         src = self._delegate
         if pysam_get_n_cigar(src) == 0:
@@ -3003,7 +3006,7 @@ cdef class AlignedSegment:
                 pos += l
 
             elif op == BAM_CINS or op == BAM_CSOFT_CLIP:
-                if not matches_only:
+                if not _matches_only:
                     for i from pos <= i < pos + l:
                         result.append((qpos, None))
                         qpos += 1
@@ -3011,7 +3014,7 @@ cdef class AlignedSegment:
                     qpos += l
 
             elif op == BAM_CDEL or op == BAM_CREF_SKIP:
-                if not matches_only:
+                if not _matches_only:
                     for i from pos <= i < pos + l:
                         result.append((None, i))
                 pos += l


### PR DESCRIPTION
Get_aligned_pairs was broken for softly clipped reads, and match/mismatch CIGAR commands.
I added test cases for all CIGAR commands.
Padding (6 - BAM_CPAD) is still unsupported, but now raises a NotImplementedError.

Also, I've integrated my recently suggested get_aligned_pairs_matches_only() which allows great speed ups if all you care about is actually read bases.