### PR TITLE
Pileup read.query position none

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -61,7 +61,7 @@ reads are represented as :class:`~pysam.PileupRead` objects in the
     print ("\ncoverage at base %s = %s" %
             (pileupcolumn.pos, pileupcolumn.n))
     for pileupread in pileupcolumn.pileups:
-        if not pileupread.is_del and not pileupread.is_refskip:  # query position is undefined if is_del is set.
+        if not pileupread.is_del and not pileupread.is_refskip:  # query position is None if is_del or is_refskip is set.
             print ('\tbase in read %s = %s' %
                     (pileupread.alignment.query_name,
                          pileupread.alignment.query_sequence[pileupread.query_position]))

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -58,12 +58,13 @@ reads are represented as :class:`~pysam.PileupRead` objects in the
     import pysam
     samfile = pysam.AlignmentFile("ex1.bam", "rb" )
     for pileupcolumn in samfile.pileup("chr1", 100, 120):
-	print ("\ncoverage at base %s = %s" %
-	        (pileupcolumn.pos, pileupcolumn.n))
-	for pileupread in pileupcolumn.pileups:
-	    print ('\tbase in read %s = %s' %
-	            (pileupread.alignment.query_name,
-                     pileupread.alignment.query_sequence[pileupread.query_position]))
+    print ("\ncoverage at base %s = %s" %
+            (pileupcolumn.pos, pileupcolumn.n))
+    for pileupread in pileupcolumn.pileups:
+        if not pileupread.is_del and not pileupread.is_refskip:  # query position is undefined if is_del is set.
+            print ('\tbase in read %s = %s' %
+                    (pileupread.alignment.query_name,
+                         pileupread.alignment.query_sequence[pileupread.query_position]))
 
     samfile.close()
 

--- a/pysam/calignmentfile.pyx
+++ b/pysam/calignmentfile.pyx
@@ -3689,11 +3689,14 @@ cdef class PileupRead:
 
     property query_position:
         """position of the read base at the pileup site, 0-based.
-        Only valid if neither is_del nor is_refskip is set.
+        None if is_del or is_refskip is set.
         
         """
         def __get__(self):
-            return self._qpos
+            if self.is_del or self.is_refskip:
+                return None
+            else:
+                return self._qpos
 
     property indel:
         """indel length; 0 for no indel, positive for ins and negative            for del"""

--- a/pysam/calignmentfile.pyx
+++ b/pysam/calignmentfile.pyx
@@ -3688,7 +3688,10 @@ cdef class PileupRead:
             return self._alignment
 
     property query_position:
-        """position of the read base at the pileup site, 0-based"""
+        """position of the read base at the pileup site, 0-based.
+        Only valid if neither is_del nor is_refskip is set.
+        
+        """
         def __get__(self):
             return self._qpos
 


### PR DESCRIPTION
This change returns None for query_position when a PileupRead is a deletion or reference skip at this reference position.
See bug #93 