### PR TITLE
Add an is_supplementary attribute to AlignedSegment.

### DIFF
--- a/pysam/calignmentfile.pyx
+++ b/pysam/calignmentfile.pyx
@@ -2837,6 +2837,12 @@ cdef class AlignedSegment:
             return (self.flag & BAM_FDUP) != 0
         def __set__(self, val):
             pysam_update_flag(self._delegate, val, BAM_FDUP)
+    property is_supplementary:
+        """true if this is a supplementary alignment"""
+        def __get__(self):
+            return (self.flag & BAM_FSUPPLEMENTARY) != 0
+        def __set__(self, val):
+            pysam_update_flag(self._delegate, val, BAM_FSUPPLEMENTARY)
 
     # 2. Coordinates and lengths
     property reference_end:

--- a/tests/AlignedSegment_test.py
+++ b/tests/AlignedSegment_test.py
@@ -107,7 +107,7 @@ class TestAlignedSegment(ReadTest):
                 "is_reverse", "mate_is_reverse",
                 "is_read1", "is_read2",
                 "is_secondary", "is_qcfail",
-                "is_duplicate"):
+                "is_duplicate", "is_supplementary"):
             setattr(b, x, True)
             self.assertEqual(getattr(b, x), True)
             checkFieldEqual(self, a, b, ("flag", x,))


### PR DESCRIPTION
This adds the `AlignedSegment.is_supplementary` property. I was not able to run the tests, unfortunately (TestUtils could not be imported and various other errors), but I believe this to be straightforward enough.