### PR TITLE
Make AlignedSegments comparable

### DIFF
--- a/pysam/calignmentfile.pyx
+++ b/pysam/calignmentfile.pyx
@@ -2449,6 +2449,14 @@ cdef class AlignedSegment:
             return retval
         return memcmp(t.data, o.data, t.l_data)
 
+    def __richcmp__(self, AlignedSegment other, int op):
+        if op == 2:  # == operator
+            return self.compare(other) == 0
+        elif op == 3:  # != operator
+            return self.compare(other) != 0
+        else:
+            return NotImplemented
+
     # Disabled so long as __cmp__ is a special method
     def __hash__(self):
         return _Py_HashPointer(<void *>self)


### PR DESCRIPTION
This adds an implementation of `__richcmp__` so one can compare AlignedSegments to each other. I’m relying on the already existing `compare()` method. Since it’s not clear what the comparison result should be if other operators such as `<` and `<=` are used, I left them out for now.

I still don’t know how to get the unit tests running (as I mentioned in the last pull request), so I haven’t added any.