### PR TITLE
fetch(reference=...) does not return mates on a different reference

### DIFF
--- a/pysam/calignmentfile.pyx
+++ b/pysam/calignmentfile.pyx
@@ -717,6 +717,10 @@ cdef class AlignmentFile:
 
         Note that a :term:`SAM` file does not allow random access. If
         *region* or *reference* are given, an exception is raised.
+        
+        Also note that using fetch() will not yield reads with mates
+        properly mapped to a different reference: all reads returned
+        by fetch() will have reference_id == next_reference_id.
 
         '''
         cdef int rtid, rstart, rend, has_coord


### PR DESCRIPTION
When using `iter = fetch(reference = "...")` and then iterating over `iter`, paired reads with mates on other references are never encountered even though they exist: `read.reference_id == read.next_reference_id` for **all** reads examined this way.

Iterating on the AlignmentFile itself (using the same file) does find pairs with mates on different references (so there are now reads for which `read.reference_id == read.next_reference_id` is **not** true).