### PR TITLE
Revert "fetch(reference=...) does not return mates on a different ref…

### DIFF
--- a/pysam/calignmentfile.pyx
+++ b/pysam/calignmentfile.pyx
@@ -717,10 +717,6 @@ cdef class AlignmentFile:
 
         Note that a :term:`SAM` file does not allow random access. If
         *region* or *reference* are given, an exception is raised.
-        
-        Also note that using fetch() will not yield reads with mates
-        properly mapped to a different reference: all reads returned
-        by fetch() will have reference_id == next_reference_id.
 
         '''
         cdef int rtid, rstart, rend, has_coord


### PR DESCRIPTION
Reverts pysam-developers/pysam#116: fetch() works properly, it was is_proper_pair attribute which (by design) filtered out reads with mates on different references.