### PR TITLE
Fix various spelling errors

### DIFF
--- a/htslib/cram/cram_index.c
+++ b/htslib/cram/cram_index.c
@@ -315,7 +315,7 @@ void cram_index_free(cram_fd *fd) {
 
 /*
  * Searches the index for the first slice overlapping a reference ID
- * and position, or one immediately preceeding it if none is found in
+ * and position, or one immediately preceding it if none is found in
  * the index to overlap this position. (Our index may have missing
  * entries, but we require at least one per reference.)
  *

--- a/pysam/calignmentfile.pyx
+++ b/pysam/calignmentfile.pyx
@@ -1474,7 +1474,7 @@ cdef class IteratorRow:
     .. note::
 
         It is usually not necessary to create an object of this class
-        explicitely. It is returned as a result of call to a
+        explicitly. It is returned as a result of call to a
         :meth:`AlignmentFile.fetch`.
 
     '''
@@ -1527,7 +1527,7 @@ cdef class IteratorRowRegion(IteratorRow):
     .. note::
 
         It is usually not necessary to create an object of this class
-        explicitely. It is returned as a result of call to a
+        explicitly. It is returned as a result of call to a
         :meth:`AlignmentFile.fetch`.
 
     """
@@ -1689,7 +1689,7 @@ cdef class IteratorRowAllRefs(IteratorRow):
 
     .. note::
         It is usually not necessary to create an object of this class
-        explicitely. It is returned as a result of call to a
+        explicitly. It is returned as a result of call to a
         :meth:`AlignmentFile.fetch`.
 
     """
@@ -1759,7 +1759,7 @@ cdef class IteratorRowSelection(IteratorRow):
 
     .. note::
         It is usually not necessary to create an object of this class
-        explicitely. It is returned as a result of call to a :meth:`AlignmentFile.fetch`.
+        explicitly. It is returned as a result of call to a :meth:`AlignmentFile.fetch`.
     """
 
     def __init__(self, AlignmentFile samfile, positions, int multiple_iterators=True):
@@ -3370,7 +3370,7 @@ cdef class AlignedSegment:
         section.
 
         *value_type* describes the type of *value* that is to entered
-        into the alignment record.. It can be set explicitely to one
+        into the alignment record.. It can be set explicitly to one
         of the valid one-letter type codes. If unset, an appropriate
         type will be chosen automatically.
 
@@ -3480,7 +3480,7 @@ cdef class AlignedSegment:
             bytesize, nvalues, values = convertBinaryTagToList(v + 1)
             return values
         else:
-            raise ValueError("unknown auxilliary type '%s'" % auxtype)
+            raise ValueError("unknown auxiliary type '%s'" % auxtype)
 
     def get_tags(self, with_value_type=False):
         """the fields in the optional aligment section.
@@ -3563,7 +3563,7 @@ cdef class AlignedSegment:
         a list of (tag, value) tuples.
 
         The :term:`value type` of the values is determined from the
-        python type. Optionally, a type may be given explicitely as
+        python type. Optionally, a type may be given explicitly as
         a third value in the tuple, For example:
 
         x.set_tags([(NM, 2, "i"), (RG, "GJP00TM04", "Z")]

--- a/pysam/ctabix.pyx
+++ b/pysam/ctabix.pyx
@@ -199,7 +199,7 @@ cdef class asBed(Parser):
     +-----------+-----------+------------------------------------------+
 
     Only the first three fields are required. Additional
-    fields are optional, but if one is defined, all the preceeding
+    fields are optional, but if one is defined, all the preceding
     need to be defined as well.
 
     ''' 

--- a/save/pysam_test2.6.py
+++ b/save/pysam_test2.6.py
@@ -355,7 +355,7 @@ class IOTest(unittest.TestCase):
 
         If *use_template* is set, the header is copied from infile using the
         template mechanism, otherwise target names and lengths are passed 
-        explicitely. 
+        explicitly. 
 
         '''
 

--- a/tests/AlignmentFile_test.py
+++ b/tests/AlignmentFile_test.py
@@ -370,7 +370,7 @@ class TestIO(unittest.TestCase):
 
         If *use_template* is set, the header is copied from infile
         using the template mechanism, otherwise target names and
-        lengths are passed explicitely.
+        lengths are passed explicitly.
 
         The *checkf* is used to determine if the files are
         equal.

--- a/tests/SamFile_test.py
+++ b/tests/SamFile_test.py
@@ -355,7 +355,7 @@ class TestIO(unittest.TestCase):
 
         If *use_template* is set, the header is copied from infile
         using the template mechanism, otherwise target names and
-        lengths are passed explicitely.
+        lengths are passed explicitly.
 
         '''
 


### PR DESCRIPTION
Debian QC tools complained about spelling errors in the source
code. This patch corrects them.