### PR TITLE
Created pFastqProxy and pFastqFile objects for working with multiple fastq records per file

### DIFF
--- a/pysam/cfaidx.pxd
+++ b/pysam/cfaidx.pxd
@@ -54,8 +54,8 @@ cdef class pFastqProxy:
     """
     Python container for pysam.cfaidx.FastqProxy with persistence.
     """
-    cdef public cython.str comment, quality, sequence, name
+    cdef public bytes comment, quality, sequence, name
     cdef cython.str tostring(self)
     cpdef array.array getQualArray(self)
 
-cdef array.array cs_to_ph(cython.str input_str)
+cdef array.array cs_to_ph(bytes input_str)

--- a/pysam/cfaidx.pxd
+++ b/pysam/cfaidx.pxd
@@ -3,9 +3,14 @@ from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t
 from libc.stdlib cimport malloc, calloc, realloc, free
 from libc.string cimport memcpy, memcmp, strncpy, strlen, strdup
 from libc.stdio cimport FILE, printf
+from cpython cimport array
+cimport cython
 
 from chtslib cimport faidx_t, kseq_t, gzFile
-                     
+
+ctypedef pFastqProxy pFastqProxy_t
+ctypedef pFastqFile pFastqFile_t
+
 cdef extern from "htslib/kstring.h" nogil:
     ctypedef struct kstring_t:
         size_t l, m
@@ -40,3 +45,17 @@ cdef class Fastafile(FastaFile):
 
 cdef class Fastqfile(FastxFile):
     pass
+
+cdef class pFastqFile:
+    cdef public FastxFile handle
+    cpdef close(self)
+
+cdef class pFastqProxy:
+    """
+    Python container for pysam.cfaidx.FastqProxy with persistence.
+    """
+    cdef public cython.str comment, quality, sequence, name
+    cdef cython.str tostring(self)
+    cpdef array.array getQualArray(self)
+
+cdef array.array cs_to_ph(cython.str input_str)

--- a/pysam/cfaidx.pyx
+++ b/pysam/cfaidx.pyx
@@ -3,6 +3,7 @@
 # adds doc-strings for sphinx
 import sys
 import os
+from array import array
 
 cdef class FastqProxy
 cdef makeFastqProxy(kseq_t * src):
@@ -420,6 +421,7 @@ __all__ = ["FastaFile",
            "Fastafile",
            "Fastqfile"]
 
-cdef array.array cs_to_ph(cython.str input_str):
+
+cdef array.array cs_to_ph(bytes input_str):
     cdef char i
     return array('B', [i - 33 for i in input_str])

--- a/pysam/cfaidx.pyx
+++ b/pysam/cfaidx.pyx
@@ -270,6 +270,59 @@ cdef class FastqProxy:
             else: return None
 
 
+cdef class pFastqProxy:
+    """
+    Python container for pysam.cfaidx.FastqProxy with persistence.
+    Needed to compare multiple fastq records from the same file.
+    In addition, has a __str__ method and a very fast getQualArray.
+    (
+    """
+    def __init__(self, FastqProxy FastqRead):
+        self.comment = FastqRead.comment
+        self.quality = FastqRead.quality
+        self.sequence = FastqRead.sequence
+        self.name = FastqRead.name
+
+    cdef cython.str tostring(self):
+        return "@%s %s\n%s\n+\n%s\n" % (self.name, self.comment,
+                                        self.sequence, self.quality)
+
+    def __str__(self):
+        return self.tostring()
+
+    cpdef array.array getQualArray(self):
+        return cs_to_ph(self.quality)
+
+
+cdef class pFastqFile(object):
+    """
+    Contains a handle for a FastqFile wrapper and converts each FastqProxy
+    to a pFastqProxy.
+    pFastqProxy objects persist, unlike FastqProxy objects, making it
+    possible to compare a number of Fastq records from a single file.
+    """
+    def __init__(self, object Fq):
+        if(isinstance(Fq, str)):
+            self.handle = FastqFile(Fq)
+        elif(isinstance(Fq, FastqFile)):
+            self.handle = Fq
+        else:
+            raise ValueError("pFastqFile can be initiated by a "
+                             "pysam.cfaidx.FastqFile or a string.")
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return pFastqProxy(next(self.handle))
+
+    cpdef close(self):
+        self.handle.close()
+
+    def refresh(self):
+        self.handle = FastqFile(self.handle.filename)
+
+
 cdef class FastxFile:
     '''*(filename)*
 
@@ -290,7 +343,7 @@ cdef class FastxFile:
         self.entry = NULL
         self._open(*args, **kwargs)
 
-    def _isOpen( self ):
+    def _isOpen(self):
         '''return true if samfile has been opened.'''
         return self.entry != NULL
 
@@ -366,3 +419,7 @@ __all__ = ["FastaFile",
            "FastqFile",
            "Fastafile",
            "Fastqfile"]
+
+cdef array.array cs_to_ph(cython.str input_str):
+    cdef char i
+    return array('B', [i - 33 for i in input_str])


### PR DESCRIPTION
These objects make it possible to work with multiple fastq records per fastq file. With FastqProxy, being a thin wrapper for kseq_t, if you appended records from a fastqfile to a list, you would get a list of FastqProxy objects all pointing to the same kseq_t object.

pFastqProxy has a __str__() function, making it easy to convert back a record into a fastq record string.
Finally, the getQualArray() method seems to be twice as fast as fromQualityString()

Where b is a pFastqProxy object:

In [4]: %timeit fromQualityString(b.quality)
The slowest run took 6.87 times longer than the fastest. This could mean that an intermediate result is being cached 
100000 loops, best of 3: 6.39 µs per loop

In [5]: %timeit b.getQualArray()
The slowest run took 6.88 times longer than the fastest. This could mean that an intermediate result is being cached 
100000 loops, best of 3: 3.64 µs per loop


This is faster because of the new conversion method I added - cs_to_ph(bytes), which treats the characters in byte strings as integers implicitly, removing the need to explicitly convert.