### PR TITLE
get_tag: expose tag type if requested with `with_value_type`

### DIFF
--- a/pysam/calignmentfile.pxd
+++ b/pysam/calignmentfile.pxd
@@ -76,7 +76,7 @@ cdef class AlignedSegment:
 
     # add an alignment tag with value to the AlignedSegment
     # an existing tag of the same name will be replaced.
-    cpdef get_tag(self, tag)
+    cpdef get_tag(self, tag, with_value_type=?)
 
     # return true if tag exists
     cpdef has_tag(self, tag)


### PR DESCRIPTION
Would you be receptive to a change along these lines?  Getting the type of a tag value is important to us.  I can add some tests.