### PR TITLE
AlignedSegment to valid SAM record string

### DIFF
--- a/pysam/calignmentfile.pxd
+++ b/pysam/calignmentfile.pxd
@@ -7,6 +7,12 @@ from libc.stdio cimport FILE, printf
 from cfaidx cimport faidx_t, Fastafile
 from chtslib cimport *
 
+cimport cpython.array
+cimport cython
+
+ctypedef cpython.array.array py_array_t
+ctypedef AlignmentFile AlignmentFile_t
+
 cdef extern from *:
     ctypedef char* const_char_ptr "const char*"
 
@@ -87,6 +93,13 @@ cdef class AlignedSegment:
     # return true if tag exists
     cpdef has_tag(self, tag)
 
+    # returns a valid sam alignment string
+    cpdef bytes tostring(self, AlignmentFile_t handle)
+
+    # returns the aux tag fields as a string.
+    cdef bytes get_tag_string(self)
+
+
 cdef class AlignmentFile:
 
     cdef object _filename
@@ -149,7 +162,7 @@ cdef class IteratorRow:
 
 cdef class IteratorRowRegion(IteratorRow):
     cdef hts_itr_t * iter
-    cdef bam1_t * getCurrent( self )
+    cdef bam1_t * getCurrent(self)
     cdef int cnext(self)
 
 cdef class IteratorRowHead(IteratorRow):
@@ -159,7 +172,7 @@ cdef class IteratorRowHead(IteratorRow):
     cdef int cnext(self)
 
 cdef class IteratorRowAll(IteratorRow):
-    cdef bam1_t * getCurrent( self )
+    cdef bam1_t * getCurrent(self)
     cdef int cnext(self)
 
 cdef class IteratorRowAllRefs(IteratorRow):
@@ -169,7 +182,7 @@ cdef class IteratorRowAllRefs(IteratorRow):
 cdef class IteratorRowSelection(IteratorRow):
     cdef int current_pos
     cdef positions
-    cdef bam1_t * getCurrent( self )
+    cdef bam1_t * getCurrent(self)
     cdef int cnext(self)
 
 cdef class IteratorColumn:
@@ -189,13 +202,13 @@ cdef class IteratorColumn:
     cdef int max_depth
 
     cdef int cnext(self)
-    cdef char * getSequence( self )
+    cdef char * getSequence(self)
     cdef setMask(self, mask)
     cdef setupIteratorData(self,
                            int tid,
                            int start,
                            int end,
-                           int multiple_iterators = ?)
+                           int multiple_iterators=?)
 
     cdef reset(self, tid, start, end)
     cdef _free_pileup_iter(self)
@@ -214,3 +227,7 @@ cdef class IndexedReads:
     cdef index
     cdef int owns_samfile
     cdef bam_hdr_t * header
+
+cdef bytes PHRED_OFFSET_STRING64, PHRED_OFFSET_STRING33
+
+cdef bytes TagToString(tuple tagtup)

--- a/pysam/calignmentfile.pxd
+++ b/pysam/calignmentfile.pxd
@@ -7,10 +7,9 @@ from libc.stdio cimport FILE, printf
 from cfaidx cimport faidx_t, Fastafile
 from chtslib cimport *
 
-cimport cpython.array
+from cpython cimport array
 cimport cython
 
-ctypedef cpython.array.array py_array_t
 ctypedef AlignmentFile AlignmentFile_t
 
 cdef extern from *:

--- a/pysam/calignmentfile.pyx
+++ b/pysam/calignmentfile.pyx
@@ -218,7 +218,6 @@ cdef convertBinaryTagToList( uint8_t * s ):
 
 cdef convertBinaryTagToArray( uint8_t * s ):
     """return bytesize, number of values list of values in s.
-    Discussion: if we 
     """
     cdef char auxtype
     cdef uint8_t byte_size
@@ -236,29 +235,21 @@ cdef convertBinaryTagToArray( uint8_t * s ):
     if auxtype == 'c':
         values = array.array('b', [(<int8_t*>s)[0] for s in xrange(s, s + nvalues)])
     elif auxtype == 'C':
-        values = array.array('B', [(<int8_t*>s)[0] for s in xrange(s, s + nvalues)])
+        values = array.array('B', [(<uint8_t*>s)[0] for s in xrange(s, s + nvalues)])
     elif auxtype == 's':
-        for x from 0 <= x < nvalues:
-            values.append((<int16_t*>s)[0])
-            s += 2
+        values = array.array('h', [(<int16_t*>s)[0] for s in xrange(s, s + nvalues * 2, 2)])
     elif auxtype == 'S':
-        for x from 0 <= x < nvalues:
-            values.append((<uint16_t*>s)[0])
-            s += 2
+        values = array.array('H', [(<uint16_t*>s)[0] for s in xrange(s, s + nvalues * 2, 2)])
     elif auxtype == 'i':
-        for x from 0 <= x < nvalues:
-            values.append((<int32_t*>s)[0])
-            s += 4
+        values = array.array('i', [(<int32_t*>s)[0] for s in xrange(s, s + nvalues * 4, 4)])
     elif auxtype == 'I':
-        for x from 0 <= x < nvalues:
-            values.append((<uint32_t*>s)[0])
-            s += 4
+        values = array.array('I', [(<uint32_t*>s)[0] for s in xrange(s, s + nvalues * 4, 4)])
     elif auxtype == 'f':
-        for x from 0 <= x < nvalues:
-            values.append((<float*>s)[0])
-            s += 4
+        values = array.array('f', [(<float*>s)[0] for s in xrange(s, s + nvalues * 4, 4)])
     else:
-        values = array.array('c', [])
+        # Throw an exception for an invalid typecode. (Overflow)
+        # This else statement permits cython to write this as a switch statement.
+        values = array.array('c', [-1e10])
 
     return byte_size, nvalues, values
 

--- a/pysam/calignmentfile.pyx
+++ b/pysam/calignmentfile.pyx
@@ -116,16 +116,16 @@ else:
 CIGAR_REGEX = re.compile( "(\d+)([MIDNSHP=X])" )
 
 PHRED_OFFSET_STRING64 = string.maketrans(
-        "".join({chr(x): chr(x + 64) for x in xrange(
-            0, 63)}.iterkeys()),
-        "".join({chr(x): chr(x + 64) for x in xrange(
-            0, 63)}.itervalues()))
+        "".join(chr(x) for x in xrange(
+            0, 63)),
+        "".join(chr(x + 64) for x in xrange(
+            0, 63)))
 
 PHRED_OFFSET_STRING33 = string.maketrans(
-        "".join({chr(x): chr(x + 33) for x in xrange(
-            0, 94)}.iterkeys()),
-        "".join({chr(x): chr(x + 33) for x in xrange(
-            0, 94)}.itervalues()))
+        "".join(chr(x) for x in xrange(
+            0, 94)),
+        "".join(chr(x + 33) for x in xrange(
+            0, 94)))
 
 #####################################################################
 # hard-coded constants
@@ -2306,13 +2306,17 @@ cpdef QualStringFromArray(array.array arr, cython.bint offset64=False):
 def toQualityString(qualities, cython.bint offset64=False):
     '''convert a list of quality score to the string
     representation used in the SAM format.'''
-    cdef char x
+    cdef char x, offset
     if qualities is None:
         return None
     elif(isinstance(qualities, array.array)):
         return QualStringFromArray(qualities, offset64=offset64)
     else:
-        return "".join([chr(x+33) for x in qualities])
+        offset = 64 if(offset64) else 33
+        if(offset64 is False):
+            return "".join([chr(x + offset) for x in qualities])
+        else:
+            return "".join([chr(x + offset) for x in qualities])
 
 
 cdef bytes TagToString(tuple tagtup):

--- a/pysam/calignmentfile.pyx
+++ b/pysam/calignmentfile.pyx
@@ -2296,7 +2296,7 @@ cdef inline object _getQualitiesRange(bam1_t *src,
     return result
 
 
-cpdef QualStringFromArray(py_array_t arr, cython.bint offset64=False):
+cpdef QualStringFromArray(array.array arr, cython.bint offset64=False):
     if(offset64 is False):
         return arr.tostring().translate(PHRED_OFFSET_STRING33)
     else:
@@ -2316,7 +2316,7 @@ def toQualityString(qualities, cython.bint offset64=False):
 
 
 cdef bytes TagToString(tuple tagtup):
-    cdef py_array_t b_aux_arr
+    cdef array.array b_aux_arr
     cdef char value_type = tagtup[2]
     cdef char* tag = tagtup[0]
     cdef double value_double
@@ -2343,9 +2343,10 @@ cdef bytes TagToString(tuple tagtup):
                 return <bytes> (tag + ":B:f" +
                                 ",".join([str(f) for f in tagtup[1]]))
             else:
-                b_aux_arr = array('L', tagtup[1])
-        size = sizeof(b_aux_arr)
-        min_value = min(tagtup[1])
+                b_aux_arr = array('l', tagtup[1])
+                # Choose long to accommodate any size integers.
+        size = sizeof(tagtup[1])
+        min_value = min(b_aux_arr)
         if(size == 1):
             if(min_value < 0):
                 ret = tag + ":B:c" + ",".join([str(i) for i in b_aux_arr])
@@ -2669,7 +2670,7 @@ cdef class AlignedSegment:
             self.rnext != self.reference_id) else "="
         cigarstring = self.cigarstring if(
             self.cigarstring is not None) else "*"
-        ret = "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s" % (
+        ret = "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" % (
             self.query_name, self.flag, handle.getrname(self.reference_id),
             self.pos + 1, self.mapq, cigarstring, mate_ref, self.mpos + 1,
             self.template_length, self.seq, self.qual, self.get_tag_string())

--- a/pysam/calignmentfile.pyx
+++ b/pysam/calignmentfile.pyx
@@ -13,6 +13,7 @@ import re
 import platform
 import warnings
 import array
+import string
 
 from cpython cimport PyErr_SetString, \
     PyBytes_Check, \
@@ -109,10 +110,22 @@ DEF SEEK_END = 2
 
 cdef char* CODE2CIGAR= "MIDNSHP=X"
 if IS_PYTHON3:
-    CIGAR2CODE = dict( [y,x] for x,y in enumerate( CODE2CIGAR) )
+    CIGAR2CODE = dict( [y,x] for x,y in enumerate( CODE2CIGAR))
 else:
-    CIGAR2CODE = dict( [ord(y),x] for x,y in enumerate( CODE2CIGAR) )
+    CIGAR2CODE = dict( [ord(y),x] for x,y in enumerate( CODE2CIGAR))
 CIGAR_REGEX = re.compile( "(\d+)([MIDNSHP=X])" )
+
+PHRED_OFFSET_STRING64 = string.maketrans(
+        "".join({chr(x): chr(x + 64) for x in xrange(
+            0, 63)}.iterkeys()),
+        "".join({chr(x): chr(x + 64) for x in xrange(
+            0, 63)}.itervalues()))
+
+PHRED_OFFSET_STRING33 = string.maketrans(
+        "".join({chr(x): chr(x + 33) for x in xrange(
+            0, 94)}.iterkeys()),
+        "".join({chr(x): chr(x + 33) for x in xrange(
+            0, 94)}.itervalues()))
 
 #####################################################################
 # hard-coded constants
@@ -302,14 +315,14 @@ cdef class AlignmentFile:
 
     '''
 
-    def __cinit__(self, *args, **kwargs ):
+    def __cinit__(self, *args, **kwargs):
         self.htsfile = NULL
         self._filename = None
         self.is_bam = False
         self.is_stream = False
         self.is_cram = False
         self.is_remote = False
-        
+
         self._open(*args, **kwargs)
 
         # allocate memory for iterator
@@ -383,7 +396,7 @@ cdef class AlignmentFile:
                        check_sq=check_sq)
             return
 
-        assert mode in ("r","w","rb","wb", "wh",
+        assert mode in ("r", "w", "rb", "wb", "wh",
                         "wbu", "rU", "wb0",
                         "rc", "wc"), \
             "invalid file opening mode `%s`" % mode
@@ -391,7 +404,7 @@ cdef class AlignmentFile:
         # close a previously opened file
         if self.htsfile != NULL:
             self.close()
-            
+
         # check if we are working with a File object
         if hasattr(filepath_or_object, "fileno"):
             filename = filepath_or_object.name
@@ -693,7 +706,7 @@ cdef class AlignmentFile:
         the header.'''
         return self.seek(self.start_offset, 0)
 
-    def seek(self, uint64_t offset, int where = 0):
+    def seek(self, uint64_t offset, int where=0):
         '''move file pointer to position *offset*, see
         :meth:`pysam.AlignmentFile.tell`.
         '''
@@ -875,7 +888,7 @@ cdef class AlignmentFile:
                 break
         else:
             raise ValueError("mate not found")
-        
+
         return mate
 
     def count(self,
@@ -900,7 +913,7 @@ cdef class AlignmentFile:
 
         if not self._isOpen():
             raise ValueError( "I/O operation on closed file" )
-            
+
         for read in self.fetch(reference=reference,
                                start=start,
                                end=end,
@@ -910,12 +923,12 @@ cdef class AlignmentFile:
 
         return counter
 
-    def pileup( self,
-                reference = None,
-                start = None,
-                end = None,
-                region = None,
-                **kwargs ):
+    def pileup(self,
+               reference=None,
+               start=None,
+               end=None,
+               region=None,
+               **kwargs):
         '''perform a :term:`pileup` within a :term:`region`. The region is
         specified by :term:`reference`, *start* and *end* (using
         0-based indexing).  Alternatively, a samtools *region* string
@@ -947,7 +960,7 @@ cdef class AlignmentFile:
 
            ``nofilter``
               uses every single read
-              
+
 
            ``samtools``
               same filter and read processing as in :term:`csamtools`
@@ -993,9 +1006,9 @@ cdef class AlignmentFile:
 
             if has_coord:
                 return IteratorColumnRegion(self,
-                                            tid = rtid,
-                                            start = rstart,
-                                            end = rend,
+                                            tid=rtid,
+                                            start=rstart,
+                                            end=rend,
                                             **kwargs )
             else:
                 return IteratorColumnAllRefs(self, **kwargs )
@@ -1004,8 +1017,8 @@ cdef class AlignmentFile:
             raise NotImplementedError( "pileup of samfiles not implemented yet" )
 
     @cython.boundscheck(False)  # we do manual bounds checking
-    def count_coverage(self, chr, start, stop, quality_threshold = 15,
-                       read_callback = 'all'):
+    def count_coverage(self, chr, start, stop, quality_threshold=15,
+                       read_callback='all'):
         """Count ACGT in a part of a AlignmentFile. 
         Return 4 array.arrays of length = stop - start,
         in order A C G T.
@@ -2036,7 +2049,7 @@ cdef class IteratorColumn:
                             int tid,
                             int start,
                             int end,
-                            int multiple_iterators = 0 ):
+                            int multiple_iterators=0 ):
         '''setup the iterator structure'''
 
         self.iter = IteratorRowRegion(self.samfile, tid, start, end, multiple_iterators)
@@ -2283,13 +2296,83 @@ cdef inline object _getQualitiesRange(bam1_t *src,
     return result
 
 
-def toQualityString(qualities):
+cpdef QualStringFromArray(py_array_t arr, cython.bint offset64=False):
+    if(offset64 is False):
+        return arr.tostring().translate(PHRED_OFFSET_STRING33)
+    else:
+        return arr.tostring().translate(PHRED_OFFSET_STRING64)
+
+
+def toQualityString(qualities, cython.bint offset64=False):
     '''convert a list of quality score to the string
     representation used in the SAM format.'''
+    cdef char x
     if qualities is None:
         return None
-    return "".join([chr(x+33) for x in qualities])
-    
+    elif(isinstance(qualities, array.array)):
+        return QualStringFromArray(qualities, offset64=offset64)
+    else:
+        return "".join([chr(x+33) for x in qualities])
+
+
+cdef bytes TagToString(tuple tagtup):
+    cdef py_array_t b_aux_arr
+    cdef char value_type = tagtup[2]
+    cdef char* tag = tagtup[0]
+    cdef double value_double
+    cdef long value_int
+    cdef bytes value_bytes
+    cdef long i, min_value
+    cdef double f
+    cdef cython.str ret
+    cdef size_t size
+    if(value_type in ['c', 'C', 'i', 'I', 's', 'S']):
+        value_int = tagtup[1]
+        ret = tag + ":i:%s" % value_int
+    elif(value_type in ['f', 'F', 'd', 'D']):
+        value_float = tagtup[1]
+        ret = tag + ":f:%s" % (value_float)
+    elif(value_type == "Z"):
+        value_bytes = tagtup[1]
+        ret = tag + ":Z:" + value_bytes
+    elif(value_type == "B"):
+        if(isinstance(tagtup[1], array.array)):
+            b_aux_arr = tagtup[1]
+        else:
+            if(isinstance(tagtup[1][0], float)):
+                return <bytes> (tag + ":B:f" +
+                                ",".join([str(f) for f in tagtup[1]]))
+            else:
+                b_aux_arr = array('L', tagtup[1])
+        size = sizeof(b_aux_arr)
+        min_value = min(tagtup[1])
+        if(size == 1):
+            if(min_value < 0):
+                ret = tag + ":B:c" + ",".join([str(i) for i in b_aux_arr])
+            else:
+                ret = tag + ":B:C" + ",".join([str(i) for i in b_aux_arr])
+        elif(size == 2):
+            if(min_value < 0):
+                ret = tag + ":B:i" + ",".join([str(i) for i in b_aux_arr])
+            else:
+                ret = tag + ":B:I" + ",".join([str(i) for i in b_aux_arr])
+        else:  # size == 4. Removed check to compile to switch statement.
+            if(min_value < 0):
+                ret = tag + ":B:s" + ",".join([str(i) for i in b_aux_arr])
+            else:
+                ret = tag + ":B:S" + ",".join([str(i) for i in b_aux_arr])
+    elif(value_type == "H"):
+        ret = tag + ":H:" + "".join([hex(i)[2:] for i in tagtup[1]])
+    elif(value_type == "A"):
+        ret = tag + ":A:" + tagtup[1]
+    else:
+        # Unrecognized character - returning the string as it was provided.
+        # An exception is not being raised because that prevents cython
+        # from being able to compile this into a switch statement for
+        # performance.
+        ret = "%s:%s:%s" % (tag, tagtup[2], tagtup[1])
+    return <bytes> ret
+
 
 def fromQualityString(quality_string):
     '''return a list of quality scores from the
@@ -2334,7 +2417,7 @@ cdef inline _get_value_type(value, maximum_value=None):
     If max is specified, the approprite type is
     returned for a range where value is the minimum.
     '''
-    
+
     if maximum_value is None:
         maximum_value = value
 
@@ -2380,7 +2463,7 @@ cdef inline _get_value_type(value, maximum_value=None):
 
 cdef inline _pack_tags(tags):
     """pack a list of tags. Each tag is a tuple of (tag, tuple).
-    
+
     Values are packed into the most space efficient data structure
     possible unless the tag contains a third field with the type code.
 
@@ -2419,7 +2502,7 @@ cdef inline _pack_tags(tags):
                 # determines type. If there is a mix of types, the
                 # result is undefined.
                 valuetype = _get_value_type(min(value), max(value))
-                            
+
             if valuetype not in datatype2format:
                 raise ValueError("invalid value type '%s'" % valuetype)
             datafmt = "2sccI%i%s" % (len(value), datatype2format[valuetype])
@@ -2447,10 +2530,10 @@ cdef inline _pack_tags(tags):
             fmts.append(fmt)
 
     return "".join(fmts), args
-    
+
 
 cdef class AlignedSegment:
-    '''Class representing an aligned segment. 
+    '''Class representing an aligned segment.
 
     This class stores a handle to the samtools C-structure representing
     an aligned read. Member read access is forwarded to the C-structure
@@ -2550,7 +2633,7 @@ cdef class AlignedSegment:
         if retval:
             return retval
         # cmp(t.l_data, o.l_data)
-        retval = (t.l_data > o.l_data) - (t.l_data < o.l_data) 
+        retval = (t.l_data > o.l_data) - (t.l_data < o.l_data)
         if retval:
             return retval
         return memcmp(t.data, o.data, t.l_data)
@@ -2579,6 +2662,25 @@ cdef class AlignedSegment:
             src.core.mpos << 8
 
         return hash_value
+
+    cpdef bytes tostring(self, AlignmentFile_t handle):
+        cdef cython.str cigarstring, mate_ref
+        mate_ref = handle.getrname(self.rnext) if(
+            self.rnext != self.reference_id) else "="
+        cigarstring = self.cigarstring if(
+            self.cigarstring is not None) else "*"
+        ret = "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s" % (
+            self.query_name, self.flag, handle.getrname(self.reference_id),
+            self.pos + 1, self.mapq, cigarstring, mate_ref, self.mpos + 1,
+            self.template_length, self.seq, self.qual, self.get_tag_string())
+        return <bytes> ret
+
+    cdef bytes get_tag_string(self):
+        cdef tuple tag
+        cdef cython.str ret = "\t".join([
+            TagToString(tag) for tag in
+            self.get_tags(with_value_type=True)])
+        return <bytes> ret
 
     ########################################################
     ## Basic attributes in order of appearance in SAM format
@@ -2823,7 +2925,7 @@ cdef class AlignedSegment:
                 # erase qualities
                 p = pysam_bam_get_qual(src)
                 p[0] = 0xff
-                
+
             self.cache_query_sequence = seq
 
             # clear cached values for quality values
@@ -2878,7 +2980,7 @@ cdef class AlignedSegment:
                 if src.core.l_qseq != 0:
                     p[0] = 0xff
                 return
-            
+
             # check for length match
             l = len(qual)
             if src.core.l_qseq != l:
@@ -2990,7 +3092,7 @@ cdef class AlignedSegment:
     # 2. Coordinates and lengths
     property reference_end:
         '''aligned reference position of the read on the reference genome.
-        
+
         reference_end points to one past the last aligned residue.
         Returns None if not available (read is unmapped or no cigar
         alignment present).
@@ -3081,7 +3183,7 @@ cdef class AlignedSegment:
             end   = _getQueryEnd(src)
             self.cache_query_alignment_qualities = _getQualitiesRange(src, start, end)
             return self.cache_query_alignment_qualities
-        
+
 
     property query_alignment_start:
         """start index of the aligned query portion of the sequence (0-based,
@@ -3626,7 +3728,7 @@ cdef class AlignedSegment:
                 raise KeyError("unknown type '%s'" % auxtype)
 
             s += 1
-            
+
             if with_value_type:
                 result.append((_charptr_to_str(auxtag), value, auxtype))
             else:

--- a/pysam/calignmentfile.pyx
+++ b/pysam/calignmentfile.pyx
@@ -2665,13 +2665,20 @@ cdef class AlignedSegment:
         return hash_value
 
     cpdef bytes tostring(self, AlignmentFile_t handle):
-        cdef cython.str cigarstring, mate_ref
-        mate_ref = handle.getrname(self.rnext) if(
-            self.rnext != self.reference_id) else "="
+        cdef cython.str cigarstring, mate_ref, ref
+        if(self.is_unmapped):
+            ref = "*"
+        else:
+            ret = handle.getrname(self.reference_id)
+        if(self.mate_is_unmapped):
+            mate_ref = "*"
+        else:
+            mate_ref = handle.getrname(self.rnext) if(
+                self.rnext != self.reference_id and self.rnext != -1) else "="
         cigarstring = self.cigarstring if(
             self.cigarstring is not None) else "*"
         ret = "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" % (
-            self.query_name, self.flag, handle.getrname(self.reference_id),
+            self.query_name, self.flag, ref,
             self.pos + 1, self.mapq, cigarstring, mate_ref, self.mpos + 1,
             self.template_length, self.seq, self.qual, self.get_tag_string())
         return <bytes> ret

--- a/pysam/calignmentfile.pyx
+++ b/pysam/calignmentfile.pyx
@@ -216,6 +216,53 @@ cdef convertBinaryTagToList( uint8_t * s ):
     return byte_size, nvalues, values
 
 
+cdef convertBinaryTagToArray( uint8_t * s ):
+    """return bytesize, number of values list of values in s.
+    Discussion: if we 
+    """
+    cdef char auxtype
+    cdef uint8_t byte_size
+    cdef int32_t nvalues
+
+    # get byte size
+    auxtype = s[0]
+    byte_size = aux_type2size( auxtype )
+    s += 1
+    # get number of values in array
+    nvalues = (<int32_t*>s)[0]
+    s += 4
+    # get values
+    values = []
+    if auxtype == 'c':
+        values = array.array('b', [(<int8_t*>s)[0] for s in xrange(s, s + nvalues)])
+    elif auxtype == 'C':
+        values = array.array('B', [(<int8_t*>s)[0] for s in xrange(s, s + nvalues)])
+    elif auxtype == 's':
+        for x from 0 <= x < nvalues:
+            values.append((<int16_t*>s)[0])
+            s += 2
+    elif auxtype == 'S':
+        for x from 0 <= x < nvalues:
+            values.append((<uint16_t*>s)[0])
+            s += 2
+    elif auxtype == 'i':
+        for x from 0 <= x < nvalues:
+            values.append((<int32_t*>s)[0])
+            s += 4
+    elif auxtype == 'I':
+        for x from 0 <= x < nvalues:
+            values.append((<uint32_t*>s)[0])
+            s += 4
+    elif auxtype == 'f':
+        for x from 0 <= x < nvalues:
+            values.append((<float*>s)[0])
+            s += 4
+    else:
+        values = array.array('c', [])
+
+    return byte_size, nvalues, values
+
+
 # valid types for SAM headers
 VALID_HEADER_TYPES = {"HD" : dict,
                       "SQ" : list,

--- a/pysam/calignmentfile.pyx
+++ b/pysam/calignmentfile.pyx
@@ -2669,7 +2669,7 @@ cdef class AlignedSegment:
         if(self.is_unmapped):
             ref = "*"
         else:
-            ret = handle.getrname(self.reference_id)
+            ref = handle.getrname(self.reference_id)
         if(self.mate_is_unmapped):
             mate_ref = "*"
         else:


### PR DESCRIPTION
Added tostring() method to AlignedSegment using its matched AlignmentFile. (See https://github.com/pysam-developers/pysam/issues/125)

This is motivated by issues with AlignmentFile's flexibility in writing - it fails to write the headers for its plain text files. You can manually write it to a stream (handle.text), but not to a file because AlignmentFile doesn't have a "w+" option, so any file header gets clobbered (and so the answer is a stream).

I also often get memory allocation issues when moving AlignedSegment_t objects around, and so when I've processed reads but sometimes want to output my new text or the read's texts, I end up with two streams. (In fact, the AlignedSegment from scratch example in the docs works for me to write, but segfaults when I try to read that file.) Of course, piped output is important for performance, and the way that pipes work is that they close the moment they receive a close message, making it impossible to force both textual output through a stdout stream and AlignmentFile("-") into the same process. (You could make an ugly hack, write one to stderr, and merge them, but that's disgusting and dangerous.)

The perfect answer for me is having a valid tostring method so that I can write them both to the same file/stream. I figure it'd be very useful to be able to append sam strings to files, giving the records a bit more mobility.

Also, added the method QualStringFromArray, which takes advantage of python's array('B').tostring() method and python's incredible fast string translate() function. Pre-computing the string.maketrans matrices makes this the fastest way I've been able to offset quality scores in a python array.

If toQualString receives a python array as an argument, it will execute the faster, more strongly-typed code.