### PR TITLE
Add pysam travis ci build status image

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,9 @@
 Pysam
 =====
 
+.. image:: https://travis-ci.org/pysam-developers/pysam.svg
+       :alt: pysam build status
+
 Pysam is a python module for reading and manipulating files in the
 SAM/BAM format. The SAM/BAM format is a way to store efficiently large
 numbers of alignments (`Li 2009`_), such as those routinely created by
@@ -15,7 +18,7 @@ The latest version is available through
 type::
   
    pip install pysam
-                                                      .
+
 Pysam documentation is available through https://readthedocs.org/ from
 `here <http://pysam.readthedocs.org/en/latest/>`_
 


### PR DESCRIPTION
pysam test builds are done on [Travis CI](https://travis-ci.org/pysam-developers/pysam) but there is no build status image on the [README.rst](https://github.com/pysam-developers/pysam/blob/master/README.rst) file.