### PR TITLE
Removes exception for custom upper-case header record tags.

### DIFF
--- a/pysam/calignmentfile.pyx
+++ b/pysam/calignmentfile.pyx
@@ -1493,16 +1493,8 @@ cdef class AlignmentFile:
                             x[key] = VALID_HEADER_FIELDS[record][key](value)
                             break
 
-                        # uppercase keys must be valid
-                        if key in VALID_HEADER_FIELDS[record]:
-                            x[key] = VALID_HEADER_FIELDS[record][key](value)
-                        # lowercase are permitted for user fields
-                        elif not key.isupper():
-                            x[key] = value
-                        else:
-                            raise ValueError(
-                                "unknown field code '%s' in record '%s'" %
-                                (key, record))
+                        # interpret type of known header record tags, default to str
+                        x[key] = VALID_HEADER_FIELDS[record].get(key, str)(value)
 
                     if VALID_HEADER_TYPES[record] == dict:
                         if record in result:

--- a/pysam/calignmentfile.pyx
+++ b/pysam/calignmentfile.pyx
@@ -89,7 +89,7 @@ VALID_HEADER_TYPES = {"HD" : dict,
 VALID_HEADERS = ("HD", "SQ", "RG", "PG", "CO")
 
 # default type conversions within SAM header records
-VALID_HEADER_FIELDS = {"HD" : {"VN" : str, "SO" : str, "GO" : str},
+KNOWN_HEADER_FIELDS = {"HD" : {"VN" : str, "SO" : str, "GO" : str},
                        "SQ" : {"SN" : str, "LN" : int, "AS" : str, 
                                "M5" : str, "SP" : str, "UR" : str,},
                        "RG" : {"ID" : str, "CN" : str, "DS" : str,
@@ -1490,11 +1490,11 @@ cdef class AlignmentFile:
                             # header. Thus, in contravention to the
                             # SAM API, consume the rest of the line.
                             key, value = "\t".join(fields[idx+1:]).split(":", 1)
-                            x[key] = VALID_HEADER_FIELDS[record][key](value)
+                            x[key] = KNOWN_HEADER_FIELDS[record][key](value)
                             break
 
                         # interpret type of known header record tags, default to str
-                        x[key] = VALID_HEADER_FIELDS[record].get(key, str)(value)
+                        x[key] = KNOWN_HEADER_FIELDS[record].get(key, str)(value)
 
                     if VALID_HEADER_TYPES[record] == dict:
                         if record in result:


### PR DESCRIPTION
The SAM specification advises as best practice to avoid use of custom upper-case header record tags without requesting their addition to the specification, but the spec does not preclude their addition or use. This pull request simply alters the header record parsing behavior to support this.

Happens to be related to #71.

o7