### PR TITLE
Add reference_name and next_reference_name attributes to AlignedSegment

### DIFF
--- a/pysam/calignedsegment.pxd
+++ b/pysam/calignedsegment.pxd
@@ -43,6 +43,9 @@ cdef class AlignedSegment:
     # object that this AlignedSegment represents
     cdef bam1_t * _delegate
 
+    # the file from which this AlignedSegment originates (can be None)
+    cdef AlignmentFile _alignment_file
+
     # caching of array properties for quick access
     cdef object cache_query_qualities
     cdef object cache_query_alignment_qualities
@@ -72,6 +75,7 @@ cdef class PileupColumn:
     cdef int tid
     cdef int pos
     cdef int n_pu
+    cdef AlignmentFile _alignment_file
 
 
 cdef class PileupRead:
@@ -85,6 +89,6 @@ cdef class PileupRead:
     cdef uint32_t _is_refskip
 
 # factor methods
-cdef makeAlignedSegment(bam1_t * src)
-cdef makePileupColumn(bam_pileup1_t ** plp, int tid, int pos, int n_pu)
-cdef inline makePileupRead(bam_pileup1_t * src)
+cdef makeAlignedSegment(bam1_t * src, AlignmentFile alignment_file)
+cdef makePileupColumn(bam_pileup1_t ** plp, int tid, int pos, int n_pu, AlignmentFile alignment_file)
+cdef inline makePileupRead(bam_pileup1_t * src, AlignmentFile alignment_file)

--- a/pysam/calignedsegment.pyx
+++ b/pysam/calignedsegment.pyx
@@ -463,20 +463,22 @@ cdef inline object getQualitiesInRange(bam1_t *src,
 #####################################################################
 ## private factory methods
 cdef class AlignedSegment
-cdef makeAlignedSegment(bam1_t * src):
+cdef makeAlignedSegment(bam1_t * src, AlignmentFile alignment_file):
     '''return an AlignedSegment object constructed from `src`'''
     # note that the following does not call __init__
     cdef AlignedSegment dest = AlignedSegment.__new__(AlignedSegment)
     dest._delegate = bam_dup1(src)
+    dest._alignment_file = alignment_file
     return dest
 
 
 cdef class PileupColumn
-cdef makePileupColumn(bam_pileup1_t ** plp, int tid, int pos, int n_pu):
+cdef makePileupColumn(bam_pileup1_t ** plp, int tid, int pos, int n_pu, AlignmentFile alignment_file):
     '''return a PileupColumn object constructed from pileup in `plp` and setting
     additional attributes.'''
     # note that the following does not call __init__
     cdef PileupColumn dest = PileupColumn.__new__(PileupColumn)
+    dest._alignment_file = alignment_file
     dest.plp = plp
     dest.tid = tid
     dest.pos = pos
@@ -484,10 +486,10 @@ cdef makePileupColumn(bam_pileup1_t ** plp, int tid, int pos, int n_pu):
     return dest
 
 cdef class PileupRead
-cdef inline makePileupRead(bam_pileup1_t * src):
+cdef inline makePileupRead(bam_pileup1_t * src, AlignmentFile alignment_file):
     '''return a PileupRead object construted from a bam_pileup1_t * object.'''
     cdef PileupRead dest = PileupRead.__new__(PileupRead)
-    dest._alignment = makeAlignedSegment(src.b)
+    dest._alignment = makeAlignedSegment(src.b, alignment_file)
     dest._qpos = src.qpos
     dest._indel = src.indel
     dest._level = src.level
@@ -564,10 +566,10 @@ cdef class AlignedSegment:
                                    self.tags)))
 
     def __copy__(self):
-        return makeAlignedSegment(self._delegate)
+        return makeAlignedSegment(self._delegate, self._alignment_file)
 
     def __deepcopy__(self, memo):
-        return makeAlignedSegment(self._delegate)
+        return makeAlignedSegment(self._delegate, self._alignment_file)
 
     def compare(self, AlignedSegment other):
         '''return -1,0,1, if contents in this are binary
@@ -718,6 +720,13 @@ cdef class AlignedSegment:
         def __set__(self, flag):
             pysam_set_flag(self._delegate, flag)
 
+    property reference_name:
+        """:term:`reference` name (None if no AlignmentFile is associated)"""
+        def __get__(self):
+            if self._alignment_file is not None:
+                return self._alignment_file.getrname(self._delegate.core.tid)
+            return None
+
     property reference_id:
         """:term:`reference` ID
 
@@ -804,6 +813,14 @@ cdef class AlignedSegment:
         def __get__(self): return self._delegate.core.mtid
         def __set__(self, mtid):
             self._delegate.core.mtid = mtid
+
+    property next_reference_name:
+        """:term:`reference` name of the mate/next read (None if no
+        AlignmentFile is associated)"""
+        def __get__(self):
+            if self._alignment_file is not None:
+                return self._alignment_file.getrname(self._delegate.core.mtid)
+            return None
 
     property next_reference_start:
         """the position of the mate/next read."""
@@ -1993,6 +2010,13 @@ cdef class PileupColumn:
         def __get__(self):
             return self.tid
 
+    property reference_name:
+        """:term:`reference` name (None if no AlignmentFile is associated)"""
+        def __get__(self):
+            if self._alignment_file is not None:
+                return self._alignment_file.getrname(self.tid)
+            return None
+
     property nsegments:
         '''number of reads mapping to this column.'''
         def __get__(self):
@@ -2017,7 +2041,7 @@ cdef class PileupColumn:
             # warning: there could be problems if self.n and self.buf are
             # out of sync.
             for x from 0 <= x < self.n_pu:
-                pileups.append(makePileupRead(&(self.plp[0][x])))
+                pileups.append(makePileupRead(&(self.plp[0][x]), self._alignment_file))
             return pileups
 
     ########################################################

--- a/pysam/calignmentfile.pyx
+++ b/pysam/calignmentfile.pyx
@@ -1554,7 +1554,7 @@ cdef class AlignmentFile:
     def __next__(self):
         cdef int ret = self.cnext()
         if (ret >= 0):
-            return makeAlignedSegment(self.b)
+            return makeAlignedSegment(self.b, self)
         elif ret == -2:
             raise IOError('truncated file')
         else:
@@ -1680,7 +1680,7 @@ cdef class IteratorRowRegion(IteratorRow):
     def __next__(self):
         self.cnext()
         if self.retval >= 0:
-            return makeAlignedSegment(self.b)
+            return makeAlignedSegment(self.b, self.samfile)
         elif self.retval == -2:
             # Note: it is currently not the case that hts_iter_next
             # returns -2 for a truncated file.
@@ -1734,10 +1734,10 @@ cdef class IteratorRowHead(IteratorRow):
             raise StopIteration
 
         cdef int ret = self.cnext()
-        if (ret >= 0):
+        if ret >= 0:
             self.current_row += 1
-            return makeAlignedSegment( self.b )
-        elif (ret == -2):
+            return makeAlignedSegment(self.b, self.samfile)
+        elif ret == -2:
             raise IOError('truncated file')
         else:
             raise StopIteration
@@ -1779,9 +1779,9 @@ cdef class IteratorRowAll(IteratorRow):
 
     def __next__(self):
         cdef int ret = self.cnext()
-        if (ret >= 0):
-            return makeAlignedSegment(self.b)
-        elif (ret == -2):
+        if ret >= 0:
+            return makeAlignedSegment(self.b, self.samfile)
+        elif ret == -2:
             raise IOError('truncated file')
         else:
             raise StopIteration
@@ -1841,7 +1841,7 @@ cdef class IteratorRowAllRefs(IteratorRow):
 
             # If current iterator is not exhausted, return aligned read
             if self.rowiter.retval > 0:
-                return makeAlignedSegment(self.rowiter.b)
+                return makeAlignedSegment(self.rowiter.b, self.samfile)
 
             self.tid += 1
 
@@ -1897,7 +1897,7 @@ cdef class IteratorRowSelection(IteratorRow):
     def __next__(self):
         cdef int ret = self.cnext()
         if (ret >= 0):
-            return makeAlignedSegment(self.b)
+            return makeAlignedSegment(self.b, self.samfile)
         elif (ret == -2):
             raise IOError('truncated file')
         else:
@@ -2219,7 +2219,8 @@ cdef class IteratorColumnRegion(IteratorColumn):
             return makePileupColumn(&self.plp,
                                    self.tid,
                                    self.pos,
-                                   self.n_plp)
+                                   self.n_plp,
+                                   self.samfile)
 
 
 cdef class IteratorColumnAllRefs(IteratorColumn):
@@ -2250,7 +2251,8 @@ cdef class IteratorColumnAllRefs(IteratorColumn):
                 return makePileupColumn(&self.plp,
                                        self.tid,
                                        self.pos,
-                                       self.n_plp)
+                                       self.n_plp,
+                                       self.samfile)
                 
             # otherwise, proceed to next reference or stop
             self.tid += 1


### PR DESCRIPTION
PileupColumn also gets a reference_name attribute. For this to work,
both AlignedSegment and PileupColumn gain an _alignment_file attribute.

No need to call getrname anymore in user code!

I cannot get the tests to run locally, so there aren’t any test cases, yet. I’m opening this PR already now to get feedback from Travis.

Another possibility of implementing this would be to only have a reference_name attribute, but the approach with the alignment_file attribute is more generic. For example, I haven’t implemented a setter for reference_name, yet, but to do that, it will also be necessary to access the AlignmentFile.