### PR TITLE
fix #171

### DIFF
--- a/pysam/calignedsegment.pxd
+++ b/pysam/calignedsegment.pxd
@@ -32,7 +32,7 @@ cdef extern from "htslib_util.h":
     void pysam_update_flag(bam1_t * b, uint16_t v, uint16_t flag)
 
 
-from calignmentfile cimport AlignmentFile
+from pysam.calignmentfile cimport AlignmentFile
 ctypedef AlignmentFile AlignmentFile_t
 
 cdef bytes TagToString(tuple tagtup)

--- a/pysam/calignedsegment.pxd
+++ b/pysam/calignedsegment.pxd
@@ -1,4 +1,4 @@
-from chtslib cimport *
+from pysam.chtslib cimport *
 
 cdef extern from "htslib_util.h":
 

--- a/pysam/calignedsegment.pyx
+++ b/pysam/calignedsegment.pyx
@@ -64,8 +64,8 @@ from cpython.version cimport PY_MAJOR_VERSION
 from cpython cimport PyErr_SetString, PyBytes_FromStringAndSize
 from libc.string cimport strchr
 
-from cutils cimport force_bytes, force_str, charptr_to_str
-from cutils cimport qualities_to_qualitystring, qualitystring_to_array, \
+from pysam.cutils cimport force_bytes, force_str, charptr_to_str
+from pysam.cutils cimport qualities_to_qualitystring, qualitystring_to_array, \
     array_to_qualitystring
 
 # Constants for binary tag conversion

--- a/pysam/calignmentfile.pxd
+++ b/pysam/calignmentfile.pxd
@@ -4,9 +4,9 @@ from libc.stdlib cimport malloc, calloc, realloc, free
 from libc.string cimport memcpy, memcmp, strncpy, strlen, strdup
 from libc.stdio cimport FILE, printf
 
-from cfaidx cimport faidx_t, Fastafile
-from calignedsegment cimport AlignedSegment
-from chtslib cimport *
+from pysam.cfaidx cimport faidx_t, Fastafile
+from pysam.calignedsegment cimport AlignedSegment
+from pysam.chtslib cimport *
 
 from cpython cimport array
 cimport cython

--- a/pysam/calignmentfile.pyx
+++ b/pysam/calignmentfile.pyx
@@ -61,9 +61,9 @@ import array
 from cpython cimport array as c_array
 from cpython.version cimport PY_MAJOR_VERSION
 
-from cutils cimport force_bytes, force_str, charptr_to_str
-from cutils cimport encode_filename, from_string_and_size
-from calignedsegment cimport makeAlignedSegment, makePileupColumn
+from pysam.cutils cimport force_bytes, force_str, charptr_to_str
+from pysam.cutils cimport encode_filename, from_string_and_size
+from pysam.calignedsegment cimport makeAlignedSegment, makePileupColumn
 
 cimport cython
 

--- a/pysam/cbcf.pxd
+++ b/pysam/cbcf.pxd
@@ -41,7 +41,7 @@ from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t
 from libc.stdlib cimport malloc, calloc, realloc, free
 from libc.string cimport memcpy, memcmp, strncpy, strlen, strdup
 
-from chtslib     cimport *
+from pysam.chtslib cimport *
 
 
 cdef class VariantHeader(object):

--- a/pysam/cbcf.pyx
+++ b/pysam/cbcf.pyx
@@ -217,8 +217,8 @@ cdef tuple COMPRESSION = ('NONE', 'GZIP', 'BGZF', 'CUSTOM')
 ## Python 3 compatibility functions
 ########################################################################
 
-from cutils cimport force_bytes, force_str, charptr_to_str
-from cutils cimport encode_filename, from_string_and_size
+from pysam.cutils cimport force_bytes, force_str, charptr_to_str
+from pysam.cutils cimport encode_filename, from_string_and_size
 
 
 ########################################################################

--- a/pysam/cfaidx.pxd
+++ b/pysam/cfaidx.pxd
@@ -6,7 +6,7 @@ from libc.stdio cimport FILE, printf
 cimport cython
 
 from cpython cimport array
-from chtslib cimport faidx_t, gzFile, kstring_t
+from pysam.chtslib cimport faidx_t, gzFile, kstring_t
 
 # These functions are put here and not in chtslib.pxd in order
 # to avoid warnings for unused functions.

--- a/pysam/cfaidx.pyx
+++ b/pysam/cfaidx.pyx
@@ -56,13 +56,13 @@ from cpython cimport PyErr_SetString, \
 
 from cpython.version cimport PY_MAJOR_VERSION
 
-from chtslib cimport \
+from pysam.chtslib cimport \
     faidx_nseq, fai_load, fai_destroy, fai_fetch, \
     faidx_fetch_seq, gzopen, gzclose
 
-from cutils cimport force_bytes, force_str, charptr_to_str
-from cutils cimport encode_filename, from_string_and_size
-from cutils cimport qualitystring_to_array
+from pysam.cutils cimport force_bytes, force_str, charptr_to_str
+from pysam.cutils cimport encode_filename, from_string_and_size
+from pysam.cutils cimport qualitystring_to_array
 
 cdef class FastqProxy
 cdef makeFastqProxy(kseq_t * src):

--- a/pysam/chtslib.pyx
+++ b/pysam/chtslib.pyx
@@ -1,7 +1,7 @@
 # cython: embedsignature=True
 # cython: profile=True
 # adds doc-strings for sphinx
-from chtslib cimport *
+from pysam.chtslib cimport *
 
 cpdef set_verbosity(int verbosity):
     u"""Set htslib's hts_verbose global variable to the specified value.

--- a/pysam/csamfile.pxd
+++ b/pysam/csamfile.pxd
@@ -1,10 +1,10 @@
-from calignmentfile cimport AlignedSegment, AlignmentFile
+from pysam.calignmentfile cimport AlignedSegment, AlignmentFile
 
 #################################################
 # Compatibility Layer for pysam < 0.8
 
 # import all declarations from htslib
-from chtslib cimport *
+from pysam.chtslib cimport *
 
 cdef class AlignedRead(AlignedSegment):
     pass

--- a/pysam/csamfile.pyx
+++ b/pysam/csamfile.pyx
@@ -19,7 +19,7 @@ from cpython cimport PyErr_SetString, \
 
 from cpython.version cimport PY_MAJOR_VERSION
 
-from calignmentfile cimport AlignmentFile, AlignedSegment
+from pysam.calignmentfile cimport AlignmentFile, AlignedSegment
 
 
 cdef class Samfile(AlignmentFile):

--- a/pysam/csamtools.pyx
+++ b/pysam/csamtools.pyx
@@ -5,7 +5,7 @@ import tempfile
 import os
 import sys
 
-from cutils cimport force_bytes, force_cmdline_bytes
+from pysam.cutils cimport force_bytes, force_cmdline_bytes
 
 class Outs:
     '''http://mail.python.org/pipermail/python-list/2000-June/038406.html'''

--- a/pysam/ctabix.pxd
+++ b/pysam/ctabix.pxd
@@ -13,7 +13,7 @@ cdef extern from "unistd.h" nogil:
     ssize_t read(int fd, void *buf, size_t count)
     int close(int fd)
 
-from chtslib cimport hts_idx_t, hts_itr_t, htsFile, \
+from pysam.chtslib cimport hts_idx_t, hts_itr_t, htsFile, \
     gzFile, tbx_t, kstring_t
 
 # These functions are put here and not in chtslib.pxd in order

--- a/pysam/ctabix.pyx
+++ b/pysam/ctabix.pyx
@@ -66,16 +66,16 @@ from cpython cimport PyErr_SetString, PyBytes_Check, \
 
 from cpython.version cimport PY_MAJOR_VERSION
 
-cimport ctabixproxies
+cimport pysam.ctabixproxies as ctabixproxies
 
-from chtslib cimport htsFile, hts_open, hts_close, HTS_IDX_START,\
+from pysam.chtslib cimport htsFile, hts_open, hts_close, HTS_IDX_START,\
     BGZF, bgzf_open, bgzf_close, bgzf_write, gzFile, \
     tbx_index_build, tbx_index_load, tbx_itr_queryi, tbx_itr_querys, \
     tbx_conf_t, tbx_seqnames, tbx_itr_next, tbx_itr_destroy, \
     tbx_destroy, gzopen, gzclose, gzerror, gzdopen
 
-from cutils cimport force_bytes, force_str, charptr_to_str
-from cutils cimport encode_filename, from_string_and_size
+from pysam.cutils cimport force_bytes, force_str, charptr_to_str
+from pysam.cutils cimport encode_filename, from_string_and_size
 
 cdef class Parser:
 

--- a/pysam/ctabixproxies.pyx
+++ b/pysam/ctabixproxies.pyx
@@ -5,8 +5,8 @@ from libc.string cimport strcpy, strlen, memcmp, memcpy, memchr, strstr, strchr
 from libc.stdlib cimport free, malloc, calloc, realloc
 from libc.stdlib cimport atoi, atol, atof
 
-from cutils cimport force_bytes, force_str, charptr_to_str
-from cutils cimport encode_filename, from_string_and_size
+from pysam.cutils cimport force_bytes, force_str, charptr_to_str
+from pysam.cutils cimport encode_filename, from_string_and_size
 
 cdef char *StrOrEmpty(char * buffer):
      if buffer == NULL:

--- a/pysam/cvcf.pyx
+++ b/pysam/cvcf.pyx
@@ -54,10 +54,10 @@ from libc.stdlib cimport atoi
 from libc.stdint cimport int8_t, int16_t, int32_t, int64_t
 from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t
 
-cimport ctabix
-cimport ctabixproxies
+cimport pysam.ctabix as ctabix
+cimport pysam.ctabixproxies as ctabixproxies
 
-from cutils cimport force_str
+from pysam.cutils cimport force_str
 
 import pysam
 


### PR DESCRIPTION
Moving from relative to absolute imports prevents compiled '.c' files generated by Cython under Python 3.x from raising ``ImportError``s. 