### PR TITLE
Do not release GIL when querying Tabix

### DIFF
--- a/pysam/ctabix.pyx
+++ b/pysam/ctabix.pyx
@@ -421,16 +421,14 @@ cdef class TabixFile:
 
         if region is None:
             # without region or reference - iterate from start
-            with nogil:
-                iter = tbx_itr_queryi(fileobj.index,
-                                      HTS_IDX_START,
-                                      0,
-                                      0)
+            iter = tbx_itr_queryi(fileobj.index,
+                                  HTS_IDX_START,
+                                  0,
+                                  0)
         else:
             s = force_bytes(region, encoding=fileobj.encoding)
             cstr = s
-            with nogil:
-                iter = tbx_itr_querys(fileobj.index, cstr)
+            iter = tbx_itr_querys(fileobj.index, cstr)
 
         if iter == NULL:
             if region is None:
@@ -573,12 +571,11 @@ cdef class TabixIterator:
         cdef int retval
 
         while 1:
-            with nogil:
-                retval = tbx_itr_next(
-                    self.tabixfile.tabixfile,
-                    self.tabixfile.index,
-                    self.iterator,
-                    &self.buffer)
+            retval = tbx_itr_next(
+                self.tabixfile.tabixfile,
+                self.tabixfile.index,
+                self.iterator,
+                &self.buffer)
 
             if retval < 0:
                 break


### PR DESCRIPTION
Tabix is not thread-safe and the GIL should not be released while querying.

In my case, I was running a Tornado web server with several threaded workers that performed Tabix queries simultaneously.

This would result in error messages from the Tabix C-library such as this:
```
[E::get_intv] failed to parse TBX_GENERIC, was wrong -p [type] used?
The offending line was: "	+	NM_012231	6	intronic	CDS	238	682833521792	34873960360784	iffffffffffffffffff”
```

The error message indicated that lines from the indexed file where read incompletely and the issue disappeared when I switched to using just a single worker.

The attached patch solved the issue for me.