### PR TITLE
Fix rendering error on readthedocs

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -58,14 +58,14 @@ reads are represented as :class:`~pysam.PileupRead` objects in the
     import pysam
     samfile = pysam.AlignmentFile("ex1.bam", "rb" )
     for pileupcolumn in samfile.pileup("chr1", 100, 120):
-	print ("\ncoverage at base %s = %s" %
-            (pileupcolumn.pos, pileupcolumn.n))
-    for pileupread in pileupcolumn.pileups:
-        if not pileupread.is_del and not pileupread.is_refskip:
-	    # query position is None if is_del or is_refskip is set.
-            print ('\tbase in read %s = %s' %
-                (pileupread.alignment.query_name,
-                 pileupread.alignment.query_sequence[pileupread.query_position]))
+        print ("\ncoverage at base %s = %s" %
+               (pileupcolumn.pos, pileupcolumn.n))
+        for pileupread in pileupcolumn.pileups:
+            if not pileupread.is_del and not pileupread.is_refskip:
+                # query position is None if is_del or is_refskip is set.
+                print ('\tbase in read %s = %s' %
+                      (pileupread.alignment.query_name,
+                       pileupread.alignment.query_sequence[pileupread.query_position]))
 
     samfile.close()
 


### PR DESCRIPTION
The two for loops were rendered as separate loops instead of being nested (at http://pysam.readthedocs.org/en/latest/api.html)