### PR TITLE
get_tags() should return the tag type as a character, not an integer

### DIFF
--- a/pysam/calignedsegment.pyx
+++ b/pysam/calignedsegment.pyx
@@ -1852,7 +1852,7 @@ cdef class AlignedSegment:
             s += 1
 
             if with_value_type:
-                result.append((charptr_to_str(auxtag), value, auxtype))
+                result.append((charptr_to_str(auxtag), value, chr(auxtype)))
             else:
                 result.append((charptr_to_str(auxtag), value))
 


### PR DESCRIPTION
Currently `get_tags(with_value_type=True)` returns a tuple of (two characters, value, integer type). So an auxiliary tag like `AS:i:1` is returned as `('AS', 1, 67)` rather than `('AS', 1, 'C')`. This PR just puts things through `chr()`, which should solve the problem. I assume that this issue only arises due to how Cython dealt with the code previously.