### PR TITLE
Update cy_build.py to support pip and develop mode on Mac.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -26,7 +26,9 @@ include htslib/config.h.in
 include htslib/htslib/*.h
 include htslib/cram/*.c
 include htslib/cram/*.h
+include cy_build.py
 include pysam.py
+include requirements.txt
 
 # pysam tests
 include tests/00README.txt

--- a/cy_build.py
+++ b/cy_build.py
@@ -1,27 +1,25 @@
 import os
 import sys
 
-from distutils.sysconfig import get_config_vars, get_python_lib, get_python_version
-from distutils.extension import Extension
-from pkg_resources import Distribution
 from Cython.Distutils import build_ext
+from distutils.extension import Extension
+from distutils.sysconfig import get_config_vars, get_python_lib, get_python_version
+from pkg_resources import Distribution
+
 
 if sys.platform == 'darwin':
     config_vars = get_config_vars()
-    #config_vars['SO'] = '.dylib'
     config_vars['LDSHARED'] = config_vars['LDSHARED'].replace('-bundle', '-Wl,-x')
 
 
+def is_pip_install():
+    return "_" in os.environ and os.environ["_"].endswith("pip")
+
+
 class CyExtension(Extension):
-    def __init__(self, name, sources, include_dirs=None, define_macros=None, undef_macros=None, library_dirs=None,
-                 libraries=None, runtime_library_dirs=None, extra_objects=None, extra_compile_args=None, extra_link_args=None,
-                 export_symbols=None, swig_opts=None, depends=None, language=None, init_func=None, **kw):
-
-        self._init_func = init_func
-
-        Extension.__init__(self, name, sources, include_dirs, define_macros, undef_macros, library_dirs, libraries,
-                           runtime_library_dirs, extra_objects, extra_compile_args, extra_link_args, export_symbols,
-                           swig_opts, depends, language, **kw)
+    def __init__(self, *args, **kwargs):
+        self._init_func = kwargs.pop("init_func", None)
+        Extension.__init__(self, *args, **kwargs)
 
     def extend_includes(self, includes):
         self.include_dirs.extend(includes)
@@ -34,25 +32,38 @@ class CyExtension(Extension):
 
 
 class cy_build_ext(build_ext):
-    def build_extension(self, ext):
-        if isinstance(ext, CyExtension) and ext._init_func:
-            ext._init_func(ext)
-
-        if sys.platform == 'darwin':
-            ext.extra_link_args = ext.extra_link_args or []
-
-            egg_name = '%s.egg' % self._get_egg_name()
-            name = ext.name
-            install_name = '%s/%s/%s%s' % (get_python_lib(), egg_name, name.replace('.', os.sep), config_vars['SO'])
-
-            extra = ['-dynamiclib', '-undefined', 'dynamic_lookup', '-shared',
-                     '-Wl,-headerpad_max_install_names', '-Wl,-install_name,%s' % install_name]
-
-            ext.extra_link_args += extra
-
-        build_ext.build_extension(self, ext)
 
     def _get_egg_name(self):
         ei_cmd = self.get_finalized_command("egg_info")
         return Distribution(None, None, ei_cmd.egg_name, ei_cmd.egg_version, get_python_version(),
                             self.distribution.has_ext_modules() and self.plat_name).egg_name()
+
+    def build_extension(self, ext):
+        if isinstance(ext, CyExtension) and ext._init_func:
+            ext._init_func(ext)
+
+        if sys.platform == 'darwin':
+
+            relative_module_path = ext.name.replace(".", os.sep) + get_config_vars()["SO"]
+
+            if "develop" in sys.argv or "test" in sys.argv:
+                # develop-mode and tests use local directory
+                pkg_root = os.path.dirname(__file__)
+                linker_path = os.path.join(pkg_root, relative_module_path)
+            elif "bdist_wheel" in sys.argv or is_pip_install():
+                # making a wheel, or pip is secretly involved
+                linker_path = os.path.join(get_python_lib(), relative_module_path)
+            else:
+                # making an egg: `python setup.py install` default behavior
+                egg_name = '%s.egg' % self._get_egg_name()
+                linker_path = os.path.join(get_python_lib(), egg_name, relative_module_path)
+
+            if not ext.extra_link_args:
+                ext.extra_link_args = []
+            ext.extra_link_args += ['-dynamiclib',
+                                    '-undefined', 'dynamic_lookup',
+                                    '-shared',
+                                    '-Wl,-headerpad_max_install_names',
+                                    '-Wl,-install_name,%s' % linker_path]
+
+        build_ext.build_extension(self, ext)

--- a/cy_build.py
+++ b/cy_build.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 
 from Cython.Distutils import build_ext
@@ -15,7 +16,13 @@ if sys.platform == 'darwin':
 
 
 def is_pip_install():
-    return "_" in os.environ and os.environ["_"].endswith("pip")
+    if "_" in os.environ and os.environ["_"].endswith("pip"):
+        return True
+    if "pip-egg-info" in sys.argv:
+        return True
+    if re.search("/pip-.*-build/", __file__):
+        return True
+    return False
 
 
 class CyExtension(Extension):

--- a/cy_build.py
+++ b/cy_build.py
@@ -61,8 +61,6 @@ class cy_build_ext(build_ext):
             if not ext.extra_link_args:
                 ext.extra_link_args = []
             ext.extra_link_args += ['-dynamiclib',
-                                    '-undefined', 'dynamic_lookup',
-                                    '-shared',
                                     '-Wl,-headerpad_max_install_names',
                                     '-Wl,-install_name,%s' % linker_path]
 

--- a/cy_build.py
+++ b/cy_build.py
@@ -61,15 +61,16 @@ class cy_build_ext(build_ext):
                 linker_path = os.path.join(pkg_root, relative_module_path)
             elif "bdist_wheel" in sys.argv or is_pip_install():
                 # making a wheel, or pip is secretly involved
-                linker_path = os.path.join(get_python_lib(), relative_module_path)
+                linker_path = os.path.join("@rpath", relative_module_path)
             else:
                 # making an egg: `python setup.py install` default behavior
                 egg_name = '%s.egg' % self._get_egg_name()
-                linker_path = os.path.join(get_python_lib(), egg_name, relative_module_path)
+                linker_path = os.path.join("@rpath", egg_name, relative_module_path)
 
             if not ext.extra_link_args:
                 ext.extra_link_args = []
             ext.extra_link_args += ['-dynamiclib',
+                                    '-rpath', get_python_lib(),
                                     '-Wl,-headerpad_max_install_names',
                                     '-Wl,-install_name,%s' % linker_path,
                                     '-Wl,-x']

--- a/cy_build.py
+++ b/cy_build.py
@@ -9,7 +9,9 @@ from pkg_resources import Distribution
 
 if sys.platform == 'darwin':
     config_vars = get_config_vars()
-    config_vars['LDSHARED'] = config_vars['LDSHARED'].replace('-bundle', '-Wl,-x')
+    config_vars['LDSHARED'] = config_vars['LDSHARED'].replace('-bundle', '')
+    config_vars['SHLIB_EXT'] = '.so'
+    config_vars['SO'] = '.so'
 
 
 def is_pip_install():
@@ -62,6 +64,7 @@ class cy_build_ext(build_ext):
                 ext.extra_link_args = []
             ext.extra_link_args += ['-dynamiclib',
                                     '-Wl,-headerpad_max_install_names',
-                                    '-Wl,-install_name,%s' % linker_path]
+                                    '-Wl,-install_name,%s' % linker_path,
+                                    '-Wl,-x']
 
         build_ext.build_extension(self, ext)

--- a/pysam/__init__.py
+++ b/pysam/__init__.py
@@ -43,9 +43,26 @@ from pysam.version import __version__, __samtools_version__
 def get_include():
     '''return a list of include directories.'''
     dirname = os.path.abspath(os.path.join(os.path.dirname(__file__)))
-    return [dirname,
-            os.path.join(dirname, 'include', 'htslib'),
-            os.path.join(dirname, 'include', 'samtools')]
+
+    #
+    # Header files may be stored in different relative locations
+    # depending on installation mode (e.g., `python setup.py install`,
+    # `python setup.py develop`. The first entry in each list is
+    # where develop-mode headers can be found.
+    #
+    htslib_possibilities = [os.path.join(dirname, '..', 'htslib'),
+                            os.path.join(dirname, 'include', 'htslib')]
+    samtool_possibilities = [os.path.join(dirname, '..', 'samtools'),
+                             os.path.join(dirname, 'include', 'samtools')]
+
+    includes = [dirname]
+    for header_locations in [htslib_possibilities, samtool_possibilities]:
+        for header_location in header_locations:
+            if os.path.exists(header_location):
+                includes.append(os.path.abspath(header_location))
+                break
+
+    return includes
 
 
 def get_defines():


### PR DESCRIPTION
Hello,

I'm a software developer at Invitae, and we've been using pysam for quite some time. Recently I saw an update on the 0.8.5-dev branch that supports linking to pysam .so files on Mac. This made it possible for us to port an internal library to Mac. In the course of that project, I modified cy_build.py to:

a. work with pip (the current implementation depends on easy_install's egg placement)
b. work with develop mode (either `python setup.py develop` or `pip install -e`)
c. use the `@rpath` flag within the clang linker's `install_name` so shared libraries do not contain the full path of the virtual environment, if any, in which they were built.

I hope these changes are helpful, please reach out to me if you have any questions, suggestions for improvement, etc. Keep up the great work.