### PR TITLE
Add missing cbcf functionality

### DIFF
--- a/pysam/cbcf.pyx
+++ b/pysam/cbcf.pyx
@@ -5,13 +5,14 @@
 ## Cython wrapper for htslib VCF/BCF reader/writer
 ###############################################################################
 #
-# NOTICE: This code is incomplete and preliminary.  It does offer a nearly
-#         complete immutable Pythonic interface to VCF/BCF metadata and data
-#         with reading and writing capability, but has no capability (yet)
-#         to mutate the resulting data (beyond dropping all samples).
-#         Documentation still needs to be written and a unit test suite is
-#         in the works.  The code is also superficially specific to Python 2
-#         and will require a bit of work to properly adapt to Python 3.
+# NOTICE: This code is incomplete and preliminary.  It offers a nearly
+#         complete Pythonic interface to VCF/BCF metadata and data with
+#         reading and writing capability.  It has limited capability to to
+#         mutate the resulting data.  Documentation and a unit test suite
+#         are in the works.  The code is best tested under Python 2, but
+#         should also work with Python 3.  Please report any remaining
+#         str/bytes issues on the github site when using Python 3 and I'll
+#         fix them promptly.
 #
 # Here is a minimal example of how to use the API:
 #
@@ -2477,6 +2478,11 @@ cdef class VariantRecord(object):
             if pos < 1:
                 raise ValueError('Position must be positive')
             # FIXME: check start <= stop?
+            #   KBJ: Can't or else certain mutating operations will become
+            #        difficult or impossible.  e.g.  having to delete
+            #        info['END'] before being able to reset pos is going to
+            #        create subtle bugs.  Better to check this when writing
+            #        records.
             self.ptr.pos = pos - 1
 
     property start:
@@ -2487,6 +2493,7 @@ cdef class VariantRecord(object):
             if start < 0:
                 raise ValueError('Start coordinate must be non-negative')
             # FIXME: check start <= stop?
+            #   KBJ: See above.
             self.ptr.pos = start
 
     property stop:

--- a/pysam/cbcf.pyx
+++ b/pysam/cbcf.pyx
@@ -2714,7 +2714,7 @@ cdef class VariantRecordSample(object):
             return bcf_format_get_allele_indices(self)
         def __set__(self, values):
             self['GT'] = values
-        def __del__(self, values):
+        def __del__(self):
             self['GT'] = ()
 
     property alleles:
@@ -2723,7 +2723,7 @@ cdef class VariantRecordSample(object):
             return bcf_format_get_alleles(self)
         def __set__(self, values):
             self['GT'] = values
-        def __del__(self, values):
+        def __del__(self):
             self['GT'] = ()
 
     property phased:

--- a/tests/tabix_test.py
+++ b/tests/tabix_test.py
@@ -504,7 +504,7 @@ class TestParser(unittest.TestCase):
         b = copy.copy(a)
         self.assertEqual(a, b)
 
-        
+
 
 class TestIterators(unittest.TestCase):
 
@@ -812,7 +812,7 @@ class TestVCFFromVCF(TestVCF):
     # tests failing on opening
     fail_on_opening = ((24, "Error HEADING_NOT_SEPARATED_BY_TABS"),
                        )
-    
+
     check_samples = False
     coordinate_offset = 1
 
@@ -1057,7 +1057,7 @@ class TestVCFFromVariantFile(TestVCFFromVCF):
         v = smp.values()
 
         if 'GT' in smp:
-            alleles = [str(a) if a>=0 else '.' for a in smp.allele_indices]
+            alleles = [str(a) if a is not None else '.' for a in smp.allele_indices]
             v[0] = '/|'[smp.phased].join(alleles)
 
         comp = ":".join(map(convert_field, v))
@@ -1150,7 +1150,7 @@ def _TestMultipleIteratorsHelper(filename, multiple_iterators):
 
 
 class TestBackwardsCompatibility(unittest.TestCase):
-    """check if error is raised if a tabix file from an 
+    """check if error is raised if a tabix file from an
     old version is accessed from pysam"""
 
     def check(self, filename, raises=None):
@@ -1160,7 +1160,7 @@ class TestBackwardsCompatibility(unittest.TestCase):
             self.assertEqual(len(list(tf.fetch())), len(ref))
         else:
             self.assertRaises(raises, tf.fetch)
-        
+
     def testVCF0v23(self):
         self.check(os.path.join(DATADIR, "example_0v23.vcf.gz"),
                    ValueError)


### PR DESCRIPTION
This PR adds the most glaring missing functionality from cbcf -- getting and setting genotypes on samples.  It also adds:
- id/key string caching/interning
- support for Flag types
- setting alleles from any mixture of indices and strings
- a few more Py3 fixes

tests/tabix_test.py no longer fails, provided remote data are available.

@AndreasHeger : Please merge prior to release of 0.8.5.  

My next goals are to:
- translate my large suite of ad hoc testing code into UnitTests (ETA later this week)
- support header translation to allow records from one file (with one header) to be written to another file (with a different header) (ETA next week)
- complete mutating support by allowing creation of new records and adding samples to existing records (ETA next week)
- add support to htslib and pysam for UTF-8 encoded files (ETA in the coming month or so)
- add support to htslib and pysam for percent encoded INFO and FORMAT values.  This will safely allow commas, semi-colons, colons, tabs, and other currently illegal characters in string values. (ETA in the coming month or so)