### PR TITLE
Changes necessary for conda build

### DIFF
--- a/ci/conda-recipe/build.sh
+++ b/ci/conda-recipe/build.sh
@@ -2,7 +2,36 @@
 
 # Use internal htslib
 chmod a+x ./htslib/configure
-export CFLAGS="-I${PREFIX}/include/curl/ -I${PREFIX}/include -L${PREFIX}/lib"
+export CFLAGS="-I${PREFIX}/include -L${PREFIX}/lib"
 export HTSLIB_CONFIGURE_OPTIONS="--disable-libcurl"
 
-$PYTHON setup.py install
+# Use --old-and-unmanageable to disable egg-style folder naming, which is a minor hassle for RPATH stuff.
+$PYTHON setup.py install --old-and-unmanageable
+
+# Hack to find SO filenames, which are different on py35 and greater.
+# We only manually adjust rpath on OSX, so we don't need to deal with linux sufix.
+
+if [ $PY_VER == "3.5" ] && [ "$(uname)" == "Darwin" ]; then
+  SO_SUFFIX=".cpython-35m-darwin.so"
+else
+  SO_SUFFIX=".so"
+fi
+
+echo SO_SUFFIX
+
+# Hacky workaround to fix rpath pathing issues
+if [ "$(uname)" == "Darwin" ]; then
+  otool -L ${SP_DIR}/pysam/*.so
+  install_name_tool -change @rpath/pysam/libchtslib.so @rpath/python${PY_VER}/site-packages/pysam/libchtslib${SO_SUFFIX} ${SP_DIR}/pysam/calignedsegment${SO_SUFFIX}
+  install_name_tool -change @rpath/pysam/libchtslib.so @rpath/python${PY_VER}/site-packages/pysam/libchtslib${SO_SUFFIX} ${SP_DIR}/pysam/calignmentfile${SO_SUFFIX}
+  install_name_tool -change @rpath/pysam/libchtslib.so @rpath/python${PY_VER}/site-packages/pysam/libchtslib${SO_SUFFIX} ${SP_DIR}/pysam/cbcf${SO_SUFFIX}
+  install_name_tool -change @rpath/pysam/libchtslib.so @rpath/python${PY_VER}/site-packages/pysam/libchtslib${SO_SUFFIX} ${SP_DIR}/pysam/cfaidx${SO_SUFFIX}
+  install_name_tool -change @rpath/pysam/libchtslib.so @rpath/python${PY_VER}/site-packages/pysam/libchtslib${SO_SUFFIX} ${SP_DIR}/pysam/csamfile${SO_SUFFIX}
+  install_name_tool -change @rpath/pysam/libchtslib.so @rpath/python${PY_VER}/site-packages/pysam/libchtslib${SO_SUFFIX} ${SP_DIR}/pysam/ctabix${SO_SUFFIX}
+  install_name_tool -change @rpath/pysam/libchtslib.so @rpath/python${PY_VER}/site-packages/pysam/libchtslib${SO_SUFFIX} ${SP_DIR}/pysam/ctabixproxies${SO_SUFFIX}
+  install_name_tool -change @rpath/pysam/libchtslib.so @rpath/python${PY_VER}/site-packages/pysam/libchtslib${SO_SUFFIX} ${SP_DIR}/pysam/cutils${SO_SUFFIX}
+  install_name_tool -change @rpath/pysam/libchtslib.so @rpath/python${PY_VER}/site-packages/pysam/libchtslib${SO_SUFFIX} ${SP_DIR}/pysam/cvcf${SO_SUFFIX}
+  otool -L ${SP_DIR}/pysam/*.so
+else
+	echo "Skipping rpath workaround on linux"
+fi

--- a/ci/conda-recipe/meta.yaml
+++ b/ci/conda-recipe/meta.yaml
@@ -1,12 +1,15 @@
 package:
   name: pysam
-  version: 0.8.5
+  version: 0.9.0
 
 source:
   path: ../../
 
 build:
   number: 0
+  rpaths:
+    - lib/
+    - {{ "lib/python%s/site-packages/pysam/" % environ.get('PY_VER', 0) }}
 
 requirements:
   build:

--- a/cy_build.py
+++ b/cy_build.py
@@ -63,7 +63,7 @@ class cy_build_ext(build_ext):
                 # develop-mode and tests use local directory
                 pkg_root = os.path.dirname(__file__)
                 linker_path = os.path.join(pkg_root, relative_module_path)
-            elif "bdist_wheel" in sys.argv or is_pip_install():
+            elif "bdist_wheel" in sys.argv or is_pip_install() or "--old-and-unmanageable" in sys.argv:
                 # making a wheel, or pip is secretly involved
                 linker_path = os.path.join("@rpath", relative_module_path)
             else:
@@ -83,5 +83,5 @@ class cy_build_ext(build_ext):
                 ext.extra_link_args = []
 
             ext.extra_link_args += ['-Wl,-rpath,$ORIGIN']
-                                    
+
         build_ext.build_extension(self, ext)

--- a/run_tests_travis.sh
+++ b/run_tests_travis.sh
@@ -76,7 +76,13 @@ fi
 popd
 
 # Try building conda recipe first
+echo "Building pysam with conda-build"
 ~/miniconda3/bin/conda-build ci/conda-recipe/ --python=$CONDA_PY
+
+if [ $? != 0 ]; then
+    exit 1
+fi
+
 
 # install code from the repository
 python setup.py install


### PR DESCRIPTION
1.  Added (trivial) support for `--old-and-unmanageable` build option that avoids egg-style naming.
2.  Added workarounds in build.sh for manually re-naming rpaths on OSX conda builds
3.  Added extra RPATH options in meta.yaml, which fixes the conda builds on linux systems

Once we're happy with this, I'll make a PR to bioconda-recipes that points to the latest git commit.  I think it's fine to just call that "0.9.0" for the meantime.  