### PR TITLE
Add a TestDoubleFetchCram unit test

### DIFF
--- a/tests/AlignmentFile_test.py
+++ b/tests/AlignmentFile_test.py
@@ -1840,7 +1840,7 @@ class TestBTagBam(TestBTagSam):
     filename = os.path.join(DATADIR, 'example_btag.bam')
 
 
-class TestDoubleFetch(unittest.TestCase):
+class TestDoubleFetchBam(unittest.TestCase):
 
     '''check if two iterators on the same bamfile are independent.'''
 
@@ -1874,6 +1874,10 @@ class TestDoubleFetch(unittest.TestCase):
                         samfile1.fetch(until_eof=True,
                                        multiple_iterators=True)):
             self.assertEqual(a.compare(b), 0)
+
+
+class TestDoubleFetchCram(TestDoubleFetchBam):
+    filename = os.path.join(DATADIR, 'ex1.cram')
 
 
 class TestRemoteFileFTP(unittest.TestCase):


### PR DESCRIPTION
This pull request commits a failing unit test that should in my opinion pass. (It is not meant for merging directly.)

The test is a copy of the TestDoubleFetch test, but it works on `ex1.cram` instead of `ex1.bam`. It tests whether fetch()ing from a CRAM file with multiple iterators works. 

I’m not sure what the problem is, but it fails in the `testDoubleFetchWithRegion` method on the first iteration of the `for` loop. The first `.fetch()` (stored in `a`) correctly returns the first read of the region, but the second `.fetch()` (stored in `b`, with `multiple_iterators` set to True) returns the first read *of the file*.