### PR TITLE
Update calignmentfile.pyx

### DIFF
--- a/pysam/calignmentfile.pyx
+++ b/pysam/calignmentfile.pyx
@@ -589,7 +589,7 @@ cdef class AlignmentFile:
                 raise ValueError(
                     ("file has no sequences defined (mode='%s') - "
                      "is it SAM/BAM format? Consider opening with "
-                     "check_seq=True") % mode)
+                     "check_sq=False") % mode)
 
         if self.htsfile == NULL:
             raise IOError("could not open file `%s`" % filename )


### PR DESCRIPTION
Error message ("file has no sequences defined") was misleading.  The argument is check_sq, not check_seq.  Also, the message should suggest setting it to False, since True is the default.