### PR TITLE
Fix spelling/grammar issues found using Debian QA tools

### DIFF
--- a/bcftools/vcfisec.c
+++ b/bcftools/vcfisec.c
@@ -317,7 +317,7 @@ static void init_data(args_t *args)
         while (*p && *p!=',') p++;
         if ( *p==',' ) p++;
     }
-    if ( args->nwrite>1 && !args->prefix ) error("Expected -p when mutliple output files given: --write %s\n", args->write_files);
+    if ( args->nwrite>1 && !args->prefix ) error("Expected -p when multiple output files given: --write %s\n", args->write_files);
     if ( args->isec_op==OP_COMPLEMENT && args->nwrite )
     {
         if ( args->nwrite>1 ) error("Multiple files to -w make no sense with -C\n");

--- a/bcftools/vcfisec.c.pysam.c
+++ b/bcftools/vcfisec.c.pysam.c
@@ -319,7 +319,7 @@ static void init_data(args_t *args)
         while (*p && *p!=',') p++;
         if ( *p==',' ) p++;
     }
-    if ( args->nwrite>1 && !args->prefix ) error("Expected -p when mutliple output files given: --write %s\n", args->write_files);
+    if ( args->nwrite>1 && !args->prefix ) error("Expected -p when multiple output files given: --write %s\n", args->write_files);
     if ( args->isec_op==OP_COMPLEMENT && args->nwrite )
     {
         if ( args->nwrite>1 ) error("Multiple files to -w make no sense with -C\n");

--- a/pysam/calignedsegment.pyx
+++ b/pysam/calignedsegment.pyx
@@ -775,7 +775,7 @@ cdef class AlignedSegment:
         ----------
 
         htsfile -- AlignmentFile object to map numerical
-                   identifers to chromosome names.
+                   identifiers to chromosome names.
         """
 
         cdef kstring_t line
@@ -2288,7 +2288,7 @@ cdef class AlignedSegment:
 
 
 cdef class PileupColumn:
-    '''A pileup of reads at a particular reference sequence postion
+    '''A pileup of reads at a particular reference sequence position
     (:term:`column`). A pileup column contains all the reads that map
     to a certain target base.
 
@@ -2416,11 +2416,11 @@ cdef class PileupRead:
             return self._qpos
 
     property indel:
-        """indel length for the position follwing the current pileup site.
+        """indel length for the position following the current pileup site.
 
         This quantity peeks ahead to the next cigar operation in this
-        alignment. If the next operation is and insertion, indel will
-        be positve. If the next operation is a deletion, it will be
+        alignment. If the next operation is an insertion, indel will
+        be positive. If the next operation is a deletion, it will be
         negation. 0 if the next operation is not an indel.
 
         """

--- a/pysam/calignmentfile.pyx
+++ b/pysam/calignmentfile.pyx
@@ -1055,7 +1055,7 @@ cdef class AlignmentFile:
         ----------
 
         stepper : string
-           The stepper controlls how the iterator advances.
+           The stepper controls how the iterator advances.
            Possible options for the stepper are
 
            ``all``


### PR DESCRIPTION
The package linter picked these up and the notices don't go away without being fixed :)