### PR TITLE
Make force_bytes() behave the same on Python 2.7 as it does on 3.x.

### DIFF
--- a/pysam/cutils.pyx
+++ b/pysam/cutils.pyx
@@ -36,10 +36,10 @@ cpdef array_to_qualitystring(c_array.array qualities, int offset=33):
     if qualities is None:
         return None
     cdef int x
-    
+
     cdef c_array.array result
     result = c_array.clone(qualities, len(qualities), zero=False)
-    
+
     for x from 0 <= x < len(qualities):
         result[x] = qualities[x] + offset
     return force_str(result.tostring())
@@ -110,9 +110,7 @@ cdef bytes force_bytes(object s, encoding="ascii"):
     u"""convert string or unicode object to bytes, assuming
     ascii encoding.
     """
-    if not IS_PYTHON3:
-        return s
-    elif s is None:
+    if s is None:
         return None
     elif PyBytes_Check(s):
         return s


### PR DESCRIPTION
Hello,

Pysam's `fetch()` methods accept `bytes` from Python 3 and Python 2 callers, but only accept Unicode from Python 3 callers. This is because `pysam/cutils::force_bytes()` behaves differently under Python 2 than it does under Python 3.

In Python 3, `force_bytes()` converts a string or unicode object to bytes. In Python 2, it does nothing. This leads to unusual behavior: for instance, in Pysam 0.8.2.1, `AlignmentFile.fetch(u"1", 0, 100)` will raise a TypeError ("Expected bytes, got unicode") but the same call on a FastaFile object will succeed. (This seems to be a happy accident due to some string interpolation in the FastaFile method that was removed sometime before pysam 0.8.4. As of 0.9.4, neither method accepts unicode from Python 2.)

The Python 3 guard has been present for a long time; it was introduced in December 2011 (14b55f4e) but I'm not entirely sure why.

As more packages add Python 3 compatibility, consumers still using Python 2.7 can find themselves passing unicode strings without their knowledge. (For example, Pybedtools 0.7.x returns chromosome ID's as unicode to Python 2 callers, whereas 0.6.x returns them as bytes.)

This PR will make Pysam consistently accept bytes, or unicode, from Python 2, or 3.