### PR TITLE
Fix for #332: Hardclipped bases in cigar ignored by pysam.AlignedSegment.infer_query_length()

### DIFF
--- a/pysam/calignedsegment.pyx
+++ b/pysam/calignedsegment.pyx
@@ -337,9 +337,12 @@ cdef inline int32_t calculateQueryLength(bam1_t * src):
     for k from 0 <= k < pysam_get_n_cigar(src):
         op = cigar_p[k] & BAM_CIGAR_MASK
 
-        if op == BAM_CMATCH or op == BAM_CINS or \
+        if op == BAM_CMATCH or \
+           op == BAM_CINS or \
            op == BAM_CSOFT_CLIP or \
-           op == BAM_CEQUAL or op == BAM_CDIFF:
+           op == BAM_CHARD_CLIP or \
+           op == BAM_CEQUAL or \
+           op == BAM_CDIFF:
             qpos += cigar_p[k] >> BAM_CIGAR_SHIFT
 
     return qpos

--- a/tests/AlignedSegment_test.py
+++ b/tests/AlignedSegment_test.py
@@ -233,13 +233,17 @@ class TestAlignedSegment(ReadTest):
 
     def test_infer_query_length(self):
         a = self.buildRead()
-        a.cigartuples = ((0, 15))
+        # a.cigartuples = ((0, 15))
+        a.cigarstring = '15M'
         self.assertEqual(a.infer_query_length(), 15)
-        a.cigartuples = ((0, 5), (1, 5), (0, 5))
+        # a.cigartuples = ((0, 5), (1, 5), (0, 5))
+        a.cigarstring = '5M5I5M'
         self.assertEqual(a.infer_query_length(), 15)
-        a.cigartuples = ((0, 5), (2, 5), (0, 5))
+        # a.cigartuples = ((0, 5), (2, 5), (0, 5))
+        a.cigarstring = '5M5D5M'
         self.assertEqual(a.infer_query_length(), 10)
-        a.cigartuples = ((5, 5), (0, 10))
+        # a.cigartuples = ((5, 5), (0, 10))
+        a.cigarstring = '5H10M'
         self.assertEqual(a.infer_query_length(), 15)
 
     def test_get_aligned_pairs_soft_clipping(self):

--- a/tests/AlignedSegment_test.py
+++ b/tests/AlignedSegment_test.py
@@ -231,6 +231,17 @@ class TestAlignedSegment(ReadTest):
         self.assertEqual(a.get_blocks(),
                          [(20, 30), (31, 40), (40, 60)])
 
+    def test_infer_query_length(self):
+        a = self.buildRead()
+        a.cigartuples = ((0, 15))
+        self.assertEqual(a.infer_query_length(), 15)
+        a.cigartuples = ((0, 5), (1, 5), (0, 5))
+        self.assertEqual(a.infer_query_length(), 15)
+        a.cigartuples = ((0, 5), (2, 5), (0, 5))
+        self.assertEqual(a.infer_query_length(), 10)
+        a.cigartuples = ((5, 5), (0, 10))
+        self.assertEqual(a.infer_query_length(), 15)
+
     def test_get_aligned_pairs_soft_clipping(self):
         a = self.buildRead()
         a.cigartuples = ((4, 2), (0, 35), (4, 3))

--- a/tests/AlignedSegment_test.py
+++ b/tests/AlignedSegment_test.py
@@ -232,18 +232,21 @@ class TestAlignedSegment(ReadTest):
                          [(20, 30), (31, 40), (40, 60)])
 
     def test_infer_query_length(self):
+        '''Test infer_query_length on M|=|X|I|D|H|S cigar ops'''
         a = self.buildRead()
-        # a.cigartuples = ((0, 15))
         a.cigarstring = '15M'
         self.assertEqual(a.infer_query_length(), 15)
-        # a.cigartuples = ((0, 5), (1, 5), (0, 5))
+        a.cigarstring = '15='
+        self.assertEqual(a.infer_query_length(), 15)
+        a.cigarstring = '15X'
+        self.assertEqual(a.infer_query_length(), 15)
         a.cigarstring = '5M5I5M'
         self.assertEqual(a.infer_query_length(), 15)
-        # a.cigartuples = ((0, 5), (2, 5), (0, 5))
         a.cigarstring = '5M5D5M'
         self.assertEqual(a.infer_query_length(), 10)
-        # a.cigartuples = ((5, 5), (0, 10))
         a.cigarstring = '5H10M'
+        self.assertEqual(a.infer_query_length(), 15)
+        a.cigarstring = '5S10M'
         self.assertEqual(a.infer_query_length(), 15)
 
     def test_get_aligned_pairs_soft_clipping(self):


### PR DESCRIPTION
https://github.com/pysam-developers/pysam/issues/332
BAM_CHARD_CLIP ops in cigar are now used as part of calculation to infer original query length.  I have also added a test for infer_query_length().