### PR TITLE
Fix compilation with musl libc

### DIFF
--- a/htslib/htslib/knetfile.h
+++ b/htslib/htslib/knetfile.h
@@ -27,6 +27,7 @@
 #ifndef KNETFILE_H
 #define KNETFILE_H
 
+#include <sys/types.h>
 #include <stdint.h>
 #include <fcntl.h>
 


### PR DESCRIPTION
Compilation of pysam (HEAD and 0.9.1.4) with musl libc on Alpine Linux breaks due to missing type declarations in htslib/htslib/knetfile.h: 

```
gcc -fno-strict-aliasing -Os -fomit-frame-pointer -g -DNDEBUG -Os -fomit-frame-pointer -g -fPIC -Ipysam -I. -Ihtslib -I/usr/include/python2.7 -c pysam/htslib_util.c -o build/temp.linux-x86_64-2.7/pysam/htslib_util.o -Wno-unused -Wno-strict-prototypes -Wno-sign-compare -Wno-error=declaration-after-statement
In file included from pysam/htslib_util.c:7:0:
htslib/htslib/knetfile.h:88:2: error: unknown type name 'ssize_t'
  ssize_t knet_read(knetFile *fp, void *buf, size_t len);
  ^~~~~~~
error: command 'gcc' failed with exit status 1
```

The attached commit adds the necessary include to allow compilation in this environment.
