### PR TITLE
Simple fix to ValueError issue during CI build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ def run_configure(option):
 
 
 def run_make_print_config():
-    stdout = subprocess.check_output(["make", "print-config"])
+    stdout = subprocess.check_output(["make", "-s", "print-config"])
     if IS_PYTHON3:
         stdout = stdout.decode("ascii")
 


### PR DESCRIPTION
Simple fix based on @EricDeveaud's comment on #349. I was getting the same error when trying to install with `pip install pysam` on Travis CI. Now it works fine with `pip install https://github.com/standage/pysam.git`. Obviously, it would be nice if this got fixed in the next release so we could all go back to using the canonical pip version!