### PR TITLE
Support Python 3.6 file system path protocol

### DIFF
--- a/pysam/libcbcf.pyx
+++ b/pysam/libcbcf.pyx
@@ -3589,11 +3589,12 @@ cdef class VariantFile(HTSFile):
             mode = 'wb0'
 
         self.mode = mode = force_bytes(mode)
-        if isinstance(filename, str):
+        try:
             filename = encode_filename(filename)
             self.is_remote = hisremote(filename)
             self.is_stream = filename == b'-'
-        else:
+        except TypeError:
+            filename = filename
             self.is_remote = False
             self.is_stream = True
 
@@ -3660,14 +3661,14 @@ cdef class VariantFile(HTSFile):
                 cfilename = NULL
 
             # check for index and open if present
-            if self.htsfile.format.format == bcf:
+            if self.htsfile.format.format == bcf and cfilename:
                 if index_filename is not None:
                     cindex_filename = index_filename
                 with nogil:
                     idx = bcf_index_load2(cfilename, cindex_filename)
                 self.index = makeBCFIndex(self.header, idx)
 
-            elif self.htsfile.format.compression == bgzf:
+            elif self.htsfile.format.compression == bgzf and cfilename:
                 if index_filename is not None:
                     cindex_filename = index_filename
                 with nogil:

--- a/pysam/libchtslib.pyx
+++ b/pysam/libchtslib.pyx
@@ -223,6 +223,7 @@ cdef class HTSFile(object):
             else:
                 fd = self.filename.fileno()
 
+            # Replicate mode normalization done in hts_open_format
             smode = self.mode.replace(b'b', b'').replace(b'c', b'')
             if b'b' in self.mode:
                 smode += b'b'
@@ -234,7 +235,12 @@ cdef class HTSFile(object):
             if hfile == NULL:
                 raise IOError('Cannot create hfile')
 
-            filename = encode_filename('fd:{}'.format(fd))
+            try:
+                filename = self.filename.name
+            except AttributeError:
+                filename = '<fd:{}>'.format(fd)
+
+            filename = encode_filename(filename)
             cfilename = filename
             with nogil:
                 return hts_hopen(hfile, cfilename, cmode)

--- a/tests/VariantFile_test.py
+++ b/tests/VariantFile_test.py
@@ -1,8 +1,15 @@
 import os
+import sys
 import unittest
 import pysam
 import gzip
 import subprocess
+
+try:
+    from pathlib import Path
+except ImportError:
+    Path = None
+
 from TestUtils import get_temp_filename, check_lines_equal
 
 DATADIR="cbcf_data"
@@ -74,6 +81,17 @@ class TestOpening(unittest.TestCase):
                           "tmp_testEmptyFile.vcf")
 
         os.unlink("tmp_testEmptyFile.vcf")
+
+
+    if Path and sys.version_info >= (3,6):
+        def testEmptyFileVCFFromPath(self):
+            with open("tmp_testEmptyFile.vcf", "w"):
+                pass
+
+            self.assertRaises(ValueError, pysam.VariantFile,
+                              Path("tmp_testEmptyFile.vcf"))
+
+            os.unlink("tmp_testEmptyFile.vcf")
 
     def testEmptyFileVCFGZWithIndex(self):
         with open("tmp_testEmptyFile.vcf", "w"):
@@ -194,6 +212,13 @@ class TestParsing(unittest.TestCase):
         v = pysam.VariantFile(fn)
         chrom = [rec.chrom for rec in v]
         self.assertEqual(chrom, ['M', '17', '20', '20', '20'])
+
+    if Path and sys.version_info >= (3,6):
+        def testChromFromPath(self):
+            fn = os.path.join(DATADIR, self.filename)
+            v = pysam.VariantFile(Path(fn))
+            chrom = [rec.chrom for rec in v]
+            self.assertEqual(chrom, ['M', '17', '20', '20', '20'])
 
     def testPos(self):
         fn = os.path.join(DATADIR, self.filename)


### PR DESCRIPTION
Support Python 3.6 file system path protocol (using os.fsencode, available since Python 3.2).  Also fix remaining flaw preventing solution to #355 from working for VariantFiles.