### PR TITLE
Attempt to fix #406

### DIFF
--- a/pysam/libcalignedsegment.pyx
+++ b/pysam/libcalignedsegment.pyx
@@ -281,6 +281,9 @@ cdef inline packTags(tags):
                          len(value)] + list(value))
 
         elif isinstance(value, array.array):
+            valuetype = value.typecode
+            if valuetype not in datatype2format:
+                valuetype = None
             # binary tags from arrays
             if valuetype is None:
                 array_typecode = map_typecode_python_to_htslib(ord(value.typecode))


### PR DESCRIPTION
This seems to fix the issue I reported in #406. In short, for arrays the `valuetype` is always going to be set to `B`, which won't be appropriate for the type of the array. This code changes this to the type of the array or `None` if that's not a known type (e.g., if a known type ends up getting stored as something else...the ZM tag in my original example in #406 is such a case) then this is changed to `None` and generated as needed. It's likely that this means that some of the other code in `packTags()` is no longer needed.