### PR TITLE
Fix #440

### DIFF
--- a/pysam/libcalignedsegment.pyx
+++ b/pysam/libcalignedsegment.pyx
@@ -1457,14 +1457,19 @@ cdef class AlignedSegment:
 
         return result
 
-    def infer_query_length(self):
+    def infer_query_length(self, always=False):
         """infer query length from sequence or CIGAR alignment.
 
         This method deduces the query length from the CIGAR alignment
         but does not include hard-clipped bases.
 
         Returns None if CIGAR alignment is not present.
+
+        If *always* is set to True, `infer_read_length` is used instead.
+        This is deprecated and only present for backward compatibility.
         """
+        if always is True:
+            return self.infer_read_length()
         return calculateQueryLengthWithoutHardClipping(self._delegate)
 
     def infer_read_length(self):


### PR DESCRIPTION
This fixes the issue I reported in #440 with `infer_query_length()`. Old code specifying `always` will now use the new functions.

I'm getting a bug report every day or so now from people using deepTools that's due to this, so a quickish 0.11.1 release would be awesome :) If you want to pack anything else into it and need a hand then I'm happy to help.