### PR TITLE
Fix error in calling `bcf_get_genotypes` and a few other more minor glitches

### DIFF
--- a/pysam/libcbcf.pxd
+++ b/pysam/libcbcf.pxd
@@ -42,40 +42,40 @@ cdef class VariantHeader(object):
 
 
 cdef class VariantHeaderRecord(object):
-    cdef VariantHeader header
+    cdef readonly VariantHeader header
     cdef bcf_hrec_t *ptr
 
 
 cdef class VariantHeaderRecords(object):
-    cdef VariantHeader header
+    cdef readonly VariantHeader header
 
 
 cdef class VariantHeaderContigs(object):
-    cdef VariantHeader header
+    cdef readonly VariantHeader header
 
 
 cdef class VariantHeaderSamples(object):
-    cdef VariantHeader header
+    cdef readonly VariantHeader header
 
 
 cdef class VariantContig(object):
-    cdef VariantHeader header
+    cdef readonly VariantHeader header
     cdef int id
 
 
 cdef class VariantMetadata(object):
-    cdef VariantHeader header
+    cdef readonly VariantHeader header
     cdef int type
     cdef int id
 
 
 cdef class VariantHeaderMetadata(object):
-    cdef VariantHeader header
+    cdef readonly VariantHeader header
     cdef int32_t type
 
 
 cdef class VariantRecord(object):
-    cdef VariantHeader header
+    cdef readonly VariantHeader header
     cdef bcf1_t *ptr
 
 
@@ -106,7 +106,7 @@ cdef class BaseIndex(object):
 
 
 cdef class BCFIndex(BaseIndex):
-    cdef VariantHeader header
+    cdef readonly VariantHeader header
     cdef hts_idx_t *ptr
 
 

--- a/pysam/libcbcf.pyx
+++ b/pysam/libcbcf.pyx
@@ -2791,6 +2791,7 @@ cdef class VariantRecord(object):
                 raise ValueError(msg.format(self.ptr.n_sample, bcf_hdr_nsamples(dst_hdr)))
 
             bcf_translate(dst_hdr, src_hdr, self.ptr)
+            self.header = dst_header
 
     @property
     def rid(self):

--- a/pysam/libcbcf.pyx
+++ b/pysam/libcbcf.pyx
@@ -226,7 +226,8 @@ cdef inline int bcf_genotype_count(bcf_hdr_t *hdr, bcf1_t *rec, int sample) exce
         raise ValueError('genotype is only valid as a format field')
 
     cdef int32_t *gt_arr = NULL
-    cdef int ngt = bcf_get_genotypes(hdr, rec, &gt_arr, &ngt)
+    cdef int ngt = 0
+    ngt = bcf_get_genotypes(hdr, rec, &gt_arr, &ngt)
 
     if ngt <= 0 or not gt_arr:
         return 0
@@ -1309,14 +1310,10 @@ cdef class VariantHeaderRecord(object):
                 self[k] = v
 
     def pop(self, key, default=_nothing):
-        if key in self:
-            value = self[key]
-            del self[key]
-            return value
-        elif default is not _nothing:
-            return default
-        else:
+        value = self.get(key, default)
+        if value is _nothing:
             raise KeyError(key)
+        return value
 
     # Mappings are not hashable by default, but subclasses can change this
     __hash__ = None
@@ -2587,14 +2584,10 @@ cdef class VariantRecordInfo(object):
                 self[k] = v
 
     def pop(self, key, default=_nothing):
-        if key in self:
-            value = self[key]
-            del self[key]
-            return value
-        elif default is not _nothing:
-            return default
-        else:
+        value = self.get(key, default)
+        if value is _nothing:
             raise KeyError(key)
+        return value
 
     def __richcmp__(VariantRecordInfo self not None, VariantRecordInfo other not None, int op):
         if op != 2 and op != 3:
@@ -2737,14 +2730,10 @@ cdef class VariantRecordSamples(object):
                 self[k] = v
 
     def pop(self, key, default=_nothing):
-        if key in self:
-            value = self[key]
-            del self[key]
-            return value
-        elif default is not _nothing:
-            return default
-        else:
+        value = self.get(key, default)
+        if value is _nothing:
             raise KeyError(key)
+        return value
 
     def __richcmp__(VariantRecordSamples self not None, VariantRecordSamples other not None, int op):
         if op != 2 and op != 3:
@@ -2987,9 +2976,6 @@ cdef class VariantRecord(object):
 
         if bcf_unpack(r, BCF_UN_STR) < 0:
             raise ValueError('Error unpacking VariantRecord')
-
-        if r.n_allele != 0 and r.n_allele != len(values):
-            raise ValueError('Cannot reset number of alleles after initialization')
 
         values = [force_bytes(v) for v in values]
 
@@ -3321,14 +3307,10 @@ cdef class VariantRecordSample(object):
                 self[k] = v
 
     def pop(self, key, default=_nothing):
-        if key in self:
-            value = self[key]
-            del self[key]
-            return value
-        elif default is not _nothing:
-            return default
-        else:
+        value = self.get(key, default)
+        if value is _nothing:
             raise KeyError(key)
+        return value
 
     def __richcmp__(VariantRecordSample self not None, VariantRecordSample other not None, int op):
         if op != 2 and op != 3:
@@ -3436,14 +3418,10 @@ cdef class BaseIndex(object):
                 self[k] = v
 
     def pop(self, key, default=_nothing):
-        if key in self:
-            value = self[key]
-            del self[key]
-            return value
-        elif default is not _nothing:
-            return default
-        else:
+        value = self.get(key, default)
+        if value is _nothing:
             raise KeyError(key)
+        return value
 
     # Mappings are not hashable by default, but subclasses can change this
     __hash__ = None


### PR DESCRIPTION
The error in calling `bcf_get_genotypes` was due to a last minute cleanup that wasn't valid.  The remainder are:
  * fix a few ordering issues, which are side-effects of developing under Python 3.6 where all dicts are ordered.
  * fix return type of `pop()` method.
  * Make `header` attributes public/readonly.
  * rename `VariantContig.header` property to `header_record` due to conflict with the previous change.
  * Allow filter initialization of `VariantRecordFilter` in `VariantHeader.new_record` from another `VariantRecordFilter` instance.
 
Hopefully a run through Travis will pick up any residual issues.