### PR TITLE
remove implicit declarations on memset and strlen

### DIFF
--- a/pysam/tabix_util.c
+++ b/pysam/tabix_util.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
+#include <string.h>
 
 #if !(_POSIX_C_SOURCE >= 200809L || _XOPEN_SOURCE >= 700)
 /*


### PR DESCRIPTION
Fixes this problem:
~~~~
gcc -fno-strict-aliasing -g -O2 -DNDEBUG -g -fwrapv -fwrapv -O3 -Wall -Wstrict-prototypes -MD -I/sw/include -Ipysam -I. -I/sw/include -I/sw/include/python2.7 -c pysam/tabix_util.c -o build/temp.macosx-10.11-x86_64-2.7/pysam/tabix_util.o -Wno-unused -Wno-strict-prototypes -Wno-sign-compare -Wno-error=declaration-after-statement
pysam/tabix_util.c:20:3: warning: implicitly declaring library function 'memset' with type 'void
      *(void *, int, unsigned long)' [-Wimplicit-function-declaration]
  memset(*line, 0, *linelen);
  ^
pysam/tabix_util.c:20:3: note: include the header <string.h> or explicitly provide a declaration
      for 'memset'
pysam/tabix_util.c:23:11: warning: implicitly declaring library function 'strlen' with type
      'unsigned long (const char *)' [-Wimplicit-function-declaration]
  return (strlen(*line));
          ^
pysam/tabix_util.c:23:11: note: include the header <string.h> or explicitly provide a
      declaration for 'strlen'
~~~~