### PR TITLE
Use @loader_path for mac OS library paths

### DIFF
--- a/cy_build.py
+++ b/cy_build.py
@@ -61,25 +61,15 @@ class cy_build_ext(build_ext):
 
         if sys.platform == 'darwin':
             relative_module_path = ext.name.replace(".", os.sep) + get_config_vars()["SO"]
-
-            if "develop" in sys.argv or "test" in sys.argv:
-                # develop-mode and tests use local directory
-                pkg_root = os.path.dirname(__file__)
-                linker_path = os.path.join(pkg_root, relative_module_path)
-            elif "bdist_wheel" in sys.argv or is_pip_install():
-                # making a wheel, or pip is secretly involved
-                linker_path = os.path.join("@rpath", relative_module_path)
-            else:
-                # making an egg: `python setup.py install` default behavior
-                egg_name = '%s.egg' % self._get_egg_name()
-                linker_path = os.path.join("@rpath", egg_name, relative_module_path)
+            library_path = os.path.join(
+                "@loader_path", os.path.basename(relative_module_path)
+            )
 
             if not ext.extra_link_args:
                 ext.extra_link_args = []
             ext.extra_link_args += ['-dynamiclib',
-                                    '-rpath', get_python_lib(),
                                     '-Wl,-headerpad_max_install_names',
-                                    '-Wl,-install_name,%s' % linker_path,
+                                    '-Wl,-install_name,%s' % library_path,
                                     '-Wl,-x']
         else:
             if not ext.extra_link_args:

--- a/run_tests_travis.sh
+++ b/run_tests_travis.sh
@@ -25,7 +25,7 @@ conda config --add channels defaults
 conda config --add channels r
 conda config --add channels bioconda
 
-conda install -y samtools bcftools htslib
+conda install -y "samtools=1.4" "bcftools=1.4" "htslib=1.4"
 
 # Need to make C compiler and linker use the anaconda includes and libraries:
 export PREFIX=~/miniconda3/


### PR DESCRIPTION
This is somewhat of an experimental PR to solicit some feedback on an issue with building pysam eggs/wheels on mac OS. The issue is that the current configuration in [cy_build.py](https://github.com/pysam-developers/pysam/blob/d41a7c87d93f50277f4a2d1f0efc07fa19954963/cy_build.py#L80) will cause the absolute path to the interpreter to be used in the libraries' rpath, and this makes an egg/wheel unshareable between different machines, or even different Python installations on the same machine. 

To see this in more detail:
1) Build a wheel; `python setup.py bdist_wheel`
2) Unpack the egg; `cd dist && unzip pysam*.whl`
3) Inspect the rpath for any of the shared libraries (note the absolute path):
```
$ otool -l pysam/libcutils.*.so | grep -A2 LC_RPATH
          cmd LC_RPATH
      cmdsize 88
         path /Users/jvkersch/miniconda3/envs/pysam-env/lib/python3.6/site-packages (offset 12)
```

This PR removes the explicit setting of rpath, and changes the install_name for the shared libraries to something of the form `@loader_path/<library-name>`.  I was able to run the tests successfully on a clean install from wheels, and in a (different) environment with `python setup.py develop`.

Perhaps there's something I've overlooked here, please let me know if that's the case!