### PR TITLE
Fix temp file paths used in tests

### DIFF
--- a/pysam/libcfaidx.pyx
+++ b/pysam/libcfaidx.pyx
@@ -13,7 +13,7 @@
 # of the internal API. These are:
 #
 # class FastqProxy
-# class PersistentFastqProxy
+# class FastxRecord
 #
 # For backwards compatibility, the following classes are also defined:
 #

--- a/run_tests_travis.sh
+++ b/run_tests_travis.sh
@@ -65,10 +65,8 @@ make -C tests/cbcf_data
 # echo any limits that are in place
 ulimit -a
 
-# run nosetests
-# -s: do not capture stdout, conflicts with pysam.dispatch
-# -v: verbose output
-pytest -s -v tests
+# run tests
+pytest
 
 if [ $? != 0 ]; then
     exit 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,8 @@
+[bdist_wheel]
+universal = 0
+
+[tool:pytest]
+# -s: do not capture stdout, conflicts with pysam.dispatch
+# -v: verbose output
+addopts = -s -v
+testpaths = pysam tests

--- a/tests/TestUtils.py
+++ b/tests/TestUtils.py
@@ -196,7 +196,7 @@ def get_temp_filename(suffix=""):
         prefix="tmp_{}_".format(caller_name),
         suffix=suffix,
         delete=False,
-        dir=".")
+        dir="tests")
     f.close()
     return f.name
 

--- a/tests/VariantFile_test.py
+++ b/tests/VariantFile_test.py
@@ -71,52 +71,52 @@ class TestOpening(unittest.TestCase):
                           "missing_file.vcf.gz")
 
     def testEmptyFileVCF(self):
-        with open("tmp_testEmptyFile.vcf", "w"):
+        with open("tests/tmp_testEmptyFile.vcf", "w"):
             pass
 
         self.assertRaises(ValueError, pysam.VariantFile,
-                          "tmp_testEmptyFile.vcf")
+                          "tests/tmp_testEmptyFile.vcf")
 
-        os.unlink("tmp_testEmptyFile.vcf")
+        os.unlink("tests/tmp_testEmptyFile.vcf")
 
 
     if Path and sys.version_info >= (3,6):
         def testEmptyFileVCFFromPath(self):
-            with open("tmp_testEmptyFile.vcf", "w"):
+            with open("tests/tmp_testEmptyFile.vcf", "w"):
                 pass
 
             self.assertRaises(ValueError, pysam.VariantFile,
-                              Path("tmp_testEmptyFile.vcf"))
+                              Path("tests/tmp_testEmptyFile.vcf"))
 
-            os.unlink("tmp_testEmptyFile.vcf")
+            os.unlink("tests/tmp_testEmptyFile.vcf")
 
     def testEmptyFileVCFGZWithIndex(self):
-        with open("tmp_testEmptyFile.vcf", "w"):
+        with open("tests/tmp_testEmptyFile.vcf", "w"):
             pass
 
-        pysam.tabix_index("tmp_testEmptyFile.vcf",
+        pysam.tabix_index("tests/tmp_testEmptyFile.vcf",
                           preset="vcf",
                           force=True)
 
         self.assertRaises(ValueError, pysam.VariantFile,
-                          "tmp_testEmptyFile.vcf.gz")
+                          "tests/tmp_testEmptyFile.vcf.gz")
 
-        os.unlink("tmp_testEmptyFile.vcf.gz")
-        os.unlink("tmp_testEmptyFile.vcf.gz.tbi")
+        os.unlink("tests/tmp_testEmptyFile.vcf.gz")
+        os.unlink("tests/tmp_testEmptyFile.vcf.gz.tbi")
 
     def testEmptyFileVCFGZWithoutIndex(self):
-        with open("tmp_testEmptyFileWithoutIndex.vcf", "w"):
+        with open("tests/tmp_testEmptyFileWithoutIndex.vcf", "w"):
             pass
 
-        pysam.tabix_compress("tmp_testEmptyFileWithoutIndex.vcf",
-                             "tmp_testEmptyFileWithoutIndex.vcf.gz",
+        pysam.tabix_compress("tests/tmp_testEmptyFileWithoutIndex.vcf",
+                             "tests/tmp_testEmptyFileWithoutIndex.vcf.gz",
                              force=True)
 
         self.assertRaises(ValueError, pysam.VariantFile,
-                          "tmp_testEmptyFileWithoutIndex.vcf.gz")
+                          "tests/tmp_testEmptyFileWithoutIndex.vcf.gz")
 
-        os.unlink("tmp_testEmptyFileWithoutIndex.vcf")
-        os.unlink("tmp_testEmptyFileWithoutIndex.vcf.gz")
+        os.unlink("tests/tmp_testEmptyFileWithoutIndex.vcf")
+        os.unlink("tests/tmp_testEmptyFileWithoutIndex.vcf.gz")
 
     def testEmptyFileVCFOnlyHeader(self):
         with pysam.VariantFile(os.path.join(

--- a/tests/compile_test.py
+++ b/tests/compile_test.py
@@ -9,8 +9,8 @@ pysam and tabix works.
 # clean up previous compilation
 import os
 try:
-    os.unlink('_compile_test.c')
-    os.unlink('_compile_test.pyxbldc')
+    os.unlink('tests/_compile_test.c')
+    os.unlink('tests/_compile_test.pyxbldc')
 except OSError:
     pass
 

--- a/tests/tabix_test.py
+++ b/tests/tabix_test.py
@@ -138,13 +138,12 @@ class TestCompression(unittest.TestCase):
         checkBinaryEqual(self.tmpfilename + ".gz.tbi", self.filename_idx)
 
     def tearDown(self):
-
-        try:
+        if os.path.exists(self.tmpfilename):
             os.unlink(self.tmpfilename)
+        if os.path.exists(self.tmpfilename + ".gz"):
             os.unlink(self.tmpfilename + ".gz")
+        if os.path.exists(self.tmpfilename + ".gz.tbi"):
             os.unlink(self.tmpfilename + ".gz.tbi")
-        except OSError:
-            pass
 
 
 class TestCompressionSam(TestCompression):


### PR DESCRIPTION
## Scope

Running tests with nose would use the `tests` directory as CWD, so test file paths were all relative to the `tests` directory.  In contrast, pytest runs from the `pysam` base directory as CWD, so all test file file paths must be updated.  Prior changes were sufficient to ensure that existing test files were found in the correct locations, but many temporary files were created in CWD, rather than the `tests` directory.  

## Limitations

- There are still a few temp files not created in `tests`, including the 1kGenomes index file.
- In future, all temporary files should probably be written to a dedicated directory that can be removed after the test suite is run.
