### PR TITLE
Refactor parse region

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -1,4 +1,4 @@
-========
+ ========
 Glossary
 ========
 
@@ -6,12 +6,16 @@ Glossary
    :sorted:
 
    cigar
-      An alignment format string. In the python API, the cigar alignment is 
-      presented as a list of tuples ``(operation,length)``. For example, the tuple
-      ``[ (0,3), (1,5), (0,2) ]`` refers to an alignment with 3 matches, 5 insertions
-      and another 2 matches.
+      Stands for Compact Idiosyncratic Gapped Alignment Report and
+      represents a compressed (run-length encoded) pairwise alignment
+      format.  It was first defined by the Exonerate Aligner, but was alter
+      adapted and adopted as part of the :term:`SAM` standard and many other
+      aligners.  In the Python API, the cigar alignment is presented as a
+      list of tuples ``(operation,length)``.  For example, the tuple ``[
+      (0,3), (1,5), (0,2) ]`` refers to an alignment with 3 matches, 5
+      insertions and another 2 matches.
 
-   region 
+   region
       A genomic region, stated relative to a reference sequence. A
       region consists of reference name ('chr1'), start (10000), and
       end (20000). Start and end can be omitted for regions spanning
@@ -22,27 +26,30 @@ Glossary
       :term:`samtools` compatible region strings such as
       'chr1:10000:20000', which are closed, i.e., both positions 10,000
       and 20,000 are part of the interval.
- 
+
    column
       Reads that are aligned to a base in the :term:`reference` sequence.
-     
+
    tid
       The :term:`target` id. The target id is 0 or a positive integer mapping to
-      entries within the sequence dictionary in the header section of 
+      entries within the sequence dictionary in the header section of
       a :term:`TAM` file or :term:`BAM` file.
 
-   Reference
+   contig
       The sequence that a :term:`tid` refers to. For example ``chr1``, ``contig123``.
+
+   Reference
+      Synonym for contig
 
    SAM
        A textual format for storing genomic alignment information.
 
    BAM
-       Binary SAM format. BAM files are binary formatted, indexed and 
+       Binary SAM format. BAM files are binary formatted, indexed and
        allow random access.
 
    TAM
-       Text SAM file. TAM files are human readable files of 
+       Text SAM file. TAM files are human readable files of
        tab-separated fields. TAM files do not allow random access.
 
    sam file
@@ -50,7 +57,7 @@ Glossary
        be a :term:`BAM` file or a :term:`TAM` file.
 
    pileup
-      Pileup     
+      Pileup
 
    samtools
       The samtools_ package.
@@ -63,7 +70,7 @@ Glossary
 
    target
       The sequence that a read has been aligned to. Target
-      sequences have bot a numerical identifier (:term:`tid`) 
+      sequences have bot a numerical identifier (:term:`tid`)
       and an alphanumeric name (:term:`Reference`).
 
    tabix file
@@ -73,15 +80,15 @@ Glossary
       is indexed by chromosomal coordinates.
 
    tabix row
-      A row in a :term:`tabix file`. Fields within a row are 
-      tab-separated. 
+      A row in a :term:`tabix file`. Fields within a row are
+      tab-separated.
 
    soft clipping
    soft clipped
 
       In alignments with soft clipping part of the query sequence
       are not aligned. The unaligned query sequence is still part
-      of the alignment record. This is in difference to 
+      of the alignment record. This is in difference to
       :term:`hard clipped` reads.
 
    hard clipping
@@ -92,7 +99,7 @@ Glossary
       recorded in the :term:`cigar` alignment, but the removed
       sequence will not be part of the alignment record, in contrast
       to :term:`soft clipped` reads.
-     
+
    VCF
       Variant call format
 

--- a/pysam/htslib_util.c
+++ b/pysam/htslib_util.c
@@ -79,7 +79,7 @@ bam1_t * pysam_bam_update(bam1_t * b,
     {
       retval = alloc_data(b, new_size);
       if (retval == NULL)
-	return -1;
+	return NULL;
       field_start = b->data + nbytes_before;
     }
   

--- a/pysam/libcalignedsegment.pxd
+++ b/pysam/libcalignedsegment.pxd
@@ -81,5 +81,5 @@ cdef class PileupRead:
 # factor methods
 cdef makeAlignedSegment(bam1_t * src, AlignmentFile alignment_file)
 cdef makePileupColumn(bam_pileup1_t ** plp, int tid, int pos, int n_pu, AlignmentFile alignment_file)
-cdef inline makePileupRead(bam_pileup1_t * src, AlignmentFile alignment_file)
-cdef inline uint32_t get_alignment_length(bam1_t * src)
+cdef makePileupRead(bam_pileup1_t * src, AlignmentFile alignment_file)
+cdef uint32_t get_alignment_length(bam1_t * src)

--- a/pysam/libcalignmentfile.pxd
+++ b/pysam/libcalignmentfile.pxd
@@ -131,16 +131,16 @@ cdef class IteratorColumn:
     cdef setupIteratorData(self,
                            int tid,
                            int start,
-                           int end,
+                           int stop,
                            int multiple_iterators=?)
 
-    cdef reset(self, tid, start, end)
+    cdef reset(self, tid, start, stop)
     cdef _free_pileup_iter(self)
 
 
 cdef class IteratorColumnRegion(IteratorColumn):
     cdef int start
-    cdef int end
+    cdef int stop
     cdef int truncate
 
 

--- a/pysam/libchtslib.pxd
+++ b/pysam/libchtslib.pxd
@@ -807,17 +807,17 @@ cdef extern from "htslib/hts.h" nogil:
     # /*! @abstract Deallocates any memory allocated by hts_md5_init. */
     void hts_md5_destroy(hts_md5_context *ctx)
 
-    inline int hts_reg2bin(int64_t beg, int64_t end, int min_shift, int n_lvls)
-    inline int hts_bin_bot(int bin, int n_lvls)
+    int hts_reg2bin(int64_t beg, int64_t end, int min_shift, int n_lvls)
+    int hts_bin_bot(int bin, int n_lvls)
 
     # * Endianness *
-    inline int ed_is_big()
-    inline uint16_t ed_swap_2(uint16_t v)
-    inline void *ed_swap_2p(void *x)
-    inline uint32_t ed_swap_4(uint32_t v)
-    inline void *ed_swap_4p(void *x)
-    inline uint64_t ed_swap_8(uint64_t v)
-    inline void *ed_swap_8p(void *x)
+    int ed_is_big()
+    uint16_t ed_swap_2(uint16_t v)
+    void *ed_swap_2p(void *x)
+    uint32_t ed_swap_4(uint32_t v)
+    void *ed_swap_4p(void *x)
+    uint64_t ed_swap_8(uint64_t v)
+    void *ed_swap_8p(void *x)
 
 
 cdef extern from "htslib/sam.h" nogil:


### PR DESCRIPTION
## Scope

* Update glossary entry for CIGAR
* Correct error return in pysam_bam_update
* Remove incorrect use of inline declarations in external Cython definitions
* Refactor region_parsing and related code to HTSFile base class.

    Doing so exposed a bifurcation in terminology.  `AlignmentFile` uses
    `reference` and `end`, where as `VariantFile` is careful to always use
    `contig` and `stop`.  Although there is more code in the wild using
    `AlignmentFile`, I *strongly* prefer the latter nomenclature and updated all
    of the code to use that.  However, extra keyword arguments were added to
    enable backward compatible use of `reference` and `end`. 

I understand this change may be a bit controversial and I am happy to discuss before merging this PR.