### PR TITLE
Expose IO errors via IOError exceptions

### DIFF
--- a/pysam/libcalignmentfile.pyx
+++ b/pysam/libcalignmentfile.pyx
@@ -1298,7 +1298,7 @@ cdef class AlignmentFile(HTSFile):
             if errno == EPIPE:
                 errno = 0
             else:
-                raise OSError(errno, force_str(strerror(errno)))
+                raise IOError(errno, force_str(strerror(errno)))
 
     def __dealloc__(self):
         cdef int ret = 0
@@ -1324,7 +1324,7 @@ cdef class AlignmentFile(HTSFile):
             if errno == EPIPE:
                 errno = 0
             else:
-                raise OSError(errno, force_str(strerror(errno)))
+                raise IOError(errno, force_str(strerror(errno)))
 
     cpdef int write(self, AlignedSegment read) except -1:
         '''

--- a/pysam/libcbcf.pyx
+++ b/pysam/libcbcf.pyx
@@ -3755,9 +3755,9 @@ cdef class BCFIterator(BaseIterator):
 
         if not self.iter:
             if errno:
-                raise OSError(errno, strerror(errno))
+                raise IOError(errno, strerror(errno))
             else:
-                raise OSError('unable to fetch {}:{}-{}'.format(contig, start+1, stop))
+                raise IOError('unable to fetch {}:{}-{}'.format(contig, start+1, stop))
 
     def __dealloc__(self):
         if self.iter:
@@ -3790,11 +3790,11 @@ cdef class BCFIterator(BaseIterator):
             if ret == -1:
                 raise StopIteration
             elif ret == -2:
-                raise OSError('truncated file')
+                raise IOError('truncated file')
             elif errno:
-                raise OSError(errno, strerror(errno))
+                raise IOError(errno, strerror(errno))
             else:
-                raise OSError('unable to fetch next record')
+                raise IOError('unable to fetch next record')
 
         ret = bcf_subset_format(self.bcf.header.ptr, record)
 
@@ -3842,9 +3842,9 @@ cdef class TabixIterator(BaseIterator):
 
         if not self.iter:
             if errno:
-                raise OSError(errno, strerror(errno))
+                raise IOError(errno, strerror(errno))
             else:
-                raise OSError('unable to fetch {}:{}-{}'.format(contig, start+1, stop))
+                raise IOError('unable to fetch {}:{}-{}'.format(contig, start+1, stop))
 
     def __dealloc__(self):
         if self.iter:
@@ -3876,11 +3876,11 @@ cdef class TabixIterator(BaseIterator):
             if ret == -1:
                 raise StopIteration
             elif ret == -2:
-                raise OSError('truncated file')
+                raise IOError('truncated file')
             elif errno:
-                raise OSError(errno, strerror(errno))
+                raise IOError(errno, strerror(errno))
             else:
-                raise OSError('unable to fetch next record')
+                raise IOError('unable to fetch next record')
 
         cdef bcf1_t *record = bcf_init1()
 
@@ -4001,7 +4001,7 @@ cdef class VariantFile(HTSFile):
             if errno == EPIPE:
                 errno = 0
             else:
-                raise OSError(errno, force_str(strerror(errno)))
+                raise IOError(errno, force_str(strerror(errno)))
 
     def close(self):
         """closes the :class:`pysam.VariantFile`."""
@@ -4022,7 +4022,7 @@ cdef class VariantFile(HTSFile):
             if errno == EPIPE:
                 errno = 0
             else:
-                raise OSError(errno, force_str(strerror(errno)))
+                raise IOError(errno, force_str(strerror(errno)))
 
     def __iter__(self):
         if not self.is_open:
@@ -4053,11 +4053,11 @@ cdef class VariantFile(HTSFile):
             if ret == -1:
                 raise StopIteration
             elif ret == -2:
-                raise OSError('truncated file')
+                raise IOError('truncated file')
             elif errno:
-                raise OSError(errno, strerror(errno))
+                raise IOError(errno, strerror(errno))
             else:
-                raise OSError('unable to fetch next record')
+                raise IOError('unable to fetch next record')
 
         return makeVariantRecord(self.header, record)
 
@@ -4188,7 +4188,7 @@ cdef class VariantFile(HTSFile):
         elif mode.startswith(b'r'):
             # open file for reading
             if not self._exists():
-                raise OSError('file `{}` not found'.format(filename))
+                raise IOError('file `{}` not found'.format(filename))
 
             self.htsfile = self._open_htsfile()
 
@@ -4367,7 +4367,7 @@ cdef class VariantFile(HTSFile):
             ret = bcf_write1(self.htsfile, self.header.ptr, record.ptr)
 
         if ret < 0:
-            raise OSError(errno, strerror(errno))
+            raise IOError(errno, strerror(errno))
 
         return ret
 

--- a/pysam/libcbgzf.pyx
+++ b/pysam/libcbgzf.pyx
@@ -70,7 +70,7 @@ cdef class BGZFile(object):
 
         if not self.bgzf.is_write:
             import errno
-            raise OSError(errno.EBADF, "write() on read-only BGZFile object")
+            raise IOError(errno.EBADF, "write() on read-only BGZFile object")
 
         if isinstance(data, bytes):
             length = len(data)
@@ -92,7 +92,7 @@ cdef class BGZFile(object):
 
         if self.bgzf.is_write:
             import errno
-            raise OSError(errno.EBADF, "read() on write-only BGZFile object")
+            raise IOError(errno.EBADF, "read() on write-only BGZFile object")
 
         if size < 0:
             chunks = []
@@ -167,7 +167,7 @@ cdef class BGZFile(object):
         if not self.bgzf:
             raise ValueError("rewind() on closed BGZFile object")
         if not self.bgzf.is_write:
-            raise OSError("Can't rewind in write mode")
+            raise IOError("Can't rewind in write mode")
         if bgzf_seek(self.bgzf, 0, SEEK_SET) < 0:
             raise IOError('Error seeking BGZFFile object')
 

--- a/pysam/libcfaidx.pxd
+++ b/pysam/libcfaidx.pxd
@@ -39,7 +39,7 @@ cdef class FastaFile:
     cdef object _filename, _references, _lengths, reference2length
     cdef faidx_t* fastafile
     cdef char* _fetch(self, char* reference,
-                      int start, int end, int* length)
+                      int start, int end, int* length) except? NULL
 
 
 cdef class FastqProxy:

--- a/pysam/libcfaidx.pyx
+++ b/pysam/libcfaidx.pyx
@@ -290,7 +290,7 @@ cdef class FastaFile:
 
         if not seq:
             if errno:
-                raise OSError(errno, strerror(errno))
+                raise IOError(errno, strerror(errno))
             else:
                 raise ValueError("failure when retrieving sequence on '%s'" % reference)
 
@@ -312,7 +312,7 @@ cdef class FastaFile:
 
         if not seq:
             if errno:
-                raise OSError(errno, strerror(errno))
+                raise IOError(errno, strerror(errno))
             else:
                 raise ValueError("failure when retrieving sequence on '%s'" % reference)
 

--- a/pysam/libchtslib.pyx
+++ b/pysam/libchtslib.pyx
@@ -98,7 +98,7 @@ cdef class HFile(object):
             self.fp = hopen(name, mode)
 
         if not self.fp:
-            raise OSError(errno, 'failed to open HFile', self.name)
+            raise IOError(errno, 'failed to open HFile', self.name)
 
     def close(self):
         if self.fp == NULL:
@@ -108,11 +108,11 @@ cdef class HFile(object):
         self.fp = NULL
 
         if hclose(fp) != 0:
-            raise OSError(herrno(self.fp), 'failed to close HFile', self.name)
+            raise IOError(herrno(self.fp), 'failed to close HFile', self.name)
 
     def fileno(self):
         if self.fp == NULL:
-            raise OSError('operation on closed HFile')
+            raise IOError('operation on closed HFile')
         if isinstance(self.name, int):
             return self.name
         else:
@@ -135,13 +135,13 @@ cdef class HFile(object):
 
     def flush(self):
         if self.fp == NULL:
-            raise OSError('operation on closed HFile')
+            raise IOError('operation on closed HFile')
         if hflush(self.fp) != 0:
-            raise OSError(herrno(self.fp), 'failed to flush HFile', self.name)
+            raise IOError(herrno(self.fp), 'failed to flush HFile', self.name)
 
     def isatty(self):
         if self.fp == NULL:
-            raise OSError('operation on closed HFile')
+            raise IOError('operation on closed HFile')
         return False
 
     def readable(self):
@@ -149,7 +149,7 @@ cdef class HFile(object):
 
     def read(self, Py_ssize_t size=-1):
         if self.fp == NULL:
-            raise OSError('operation on closed HFile')
+            raise IOError('operation on closed HFile')
 
         if size == 0:
             return b''
@@ -169,7 +169,7 @@ cdef class HFile(object):
             ret = hread(self.fp, <void *>cpart, chunk_size)
 
             if ret < 0:
-                OSError(herrno(self.fp), 'failed to read HFile', self.name)
+                IOError(herrno(self.fp), 'failed to read HFile', self.name)
             elif not ret:
                 break
 
@@ -187,7 +187,7 @@ cdef class HFile(object):
 
     def readinto(self, buf):
         if self.fp == NULL:
-            raise OSError('operation on closed HFile')
+            raise IOError('operation on closed HFile')
 
         size = len(buf)
 
@@ -198,13 +198,13 @@ cdef class HFile(object):
         ret = hread(self.fp, <void *>mv, size)
 
         if ret < 0:
-            OSError(herrno(self.fp), 'failed to read HFile', self.name)
+            IOError(herrno(self.fp), 'failed to read HFile', self.name)
 
         return ret
 
     def readline(self, Py_ssize_t size=-1):
         if self.fp == NULL:
-            raise OSError('operation on closed HFile')
+            raise IOError('operation on closed HFile')
 
         if size == 0:
             return b''
@@ -226,7 +226,7 @@ cdef class HFile(object):
             ret = hgetln(cpart, chunk_size+1, self.fp)
 
             if ret < 0:
-                OSError(herrno(self.fp), 'failed to read HFile', self.name)
+                IOError(herrno(self.fp), 'failed to read HFile', self.name)
             elif not ret:
                 break
 
@@ -248,23 +248,23 @@ cdef class HFile(object):
 
     def seek(self, Py_ssize_t offset, int whence=SEEK_SET):
         if self.fp == NULL:
-            raise OSError('operation on closed HFile')
+            raise IOError('operation on closed HFile')
 
         cdef Py_ssize_t off = hseek(self.fp, offset, whence)
 
         if off < 0:
-            raise OSError(herrno(self.fp), 'seek failed on HFile', self.name)
+            raise IOError(herrno(self.fp), 'seek failed on HFile', self.name)
 
         return off
 
     def tell(self):
         if self.fp == NULL:
-            raise OSError('operation on closed HFile')
+            raise IOError('operation on closed HFile')
 
         ret = htell(self.fp)
 
         if ret < 0:
-            raise OSError(herrno(self.fp), 'tell failed on HFile', self.name)
+            raise IOError(herrno(self.fp), 'tell failed on HFile', self.name)
 
         return ret
 
@@ -279,12 +279,12 @@ cdef class HFile(object):
 
     def write(self, bytes b):
         if self.fp == NULL:
-            raise OSError('operation on closed HFile')
+            raise IOError('operation on closed HFile')
 
         got = hwrite(self.fp, <void *>b, len(b))
 
         if got < 0:
-            raise OSError(herrno(self.fp), 'write failed on HFile', self.name)
+            raise IOError(herrno(self.fp), 'write failed on HFile', self.name)
 
         return got
 
@@ -355,13 +355,13 @@ cdef class HTSFile(object):
 
         cdef int ret = bgzf_check_EOF(bgzfp)
         if ret < 0:
-            raise OSError(errno, 'error checking for EOF marker')
+            raise IOError(errno, 'error checking for EOF marker')
         elif ret == 0:
             msg = 'no BGZF EOF marker; file may be truncated'.format(self.filename)
             if ignore_truncation:
                 warn(msg)
             else:
-                raise OSError(msg)
+                raise IOError(msg)
 
     def __enter__(self):
         return self
@@ -482,7 +482,7 @@ cdef class HTSFile(object):
         if not self.is_open:
             raise ValueError('I/O operation on closed file')
         if self.is_stream:
-            raise OSError('seek not available in streams')
+            raise IOError('seek not available in streams')
 
         cdef int64_t ret
         if self.htsfile.format.compression == bgzf:
@@ -501,7 +501,7 @@ cdef class HTSFile(object):
         if not self.is_open:
             raise ValueError('I/O operation on closed file')
         if self.is_stream:
-            raise OSError('tell not available in streams')
+            raise IOError('tell not available in streams')
 
         cdef int64_t ret
         if self.htsfile.format.compression == bgzf:

--- a/pysam/libctabix.pyx
+++ b/pysam/libctabix.pyx
@@ -829,18 +829,18 @@ def tabix_compress(filename_in,
             r = bgzf_write(fp, buffer, c)
         if r < 0:
             free(buffer)
-            raise OSError("writing failed")
+            raise IOError("writing failed")
         
     free(buffer)
     r = bgzf_close(fp)
     if r < 0:
-        raise OSError("error %i when writing to file %s" % (r, filename_out))
+        raise IOError("error %i when writing to file %s" % (r, filename_out))
 
     r = close(fd_src)
     # an empty file will return with -1, thus ignore this.
     if r < 0:
         if not (r == -1 and is_empty):
-            raise OSError("error %i when closing file %s" % (r, filename_in))
+            raise IOError("error %i when closing file %s" % (r, filename_in))
 
 
 def tabix_index(filename, 

--- a/pysam/libcutils.pyx
+++ b/pysam/libcutils.pyx
@@ -270,7 +270,7 @@ def _pysam_dispatch(collection,
         stdout_h = c_open(force_bytes(stdout_f),
                           O_WRONLY)
         if stdout_h == -1:
-            raise OSError("error while opening {} for writing".format(stdout_f))
+            raise IOError("error while opening {} for writing".format(stdout_f))
 
         pysam_set_stdout_fn(force_bytes(stdout_f))
         pysam_set_stdout(stdout_h)


### PR DESCRIPTION
## Scope

Restructure error handling in `FastaFile.fetch`, `FastaFile._fetch`, and `VariantFile.fetch` to expose IO errors by raising Python`IOError` exceptions when `errno` is set.  The intent is to address hidden data loss (Issue #504), clarify when IO errors are occurring, and incremental to being able to add retry logic.  Testing is difficult, since simulating IO errors is not trivial.

Also added some missing detection of BCF allocation failures and raise `MemoryException`.

## Concerns

`FastaFile.fetch` still raises `ValueError` for non-IO errors.  However raising `IOError` is a non-backward compatible change and may cause problems in practice.  To me, is justifiable in order to unobfuscate when IO errors occur.