### PR TITLE
{AH} separate header into AlignmentHeader from AlignmentFile, closes …

### DIFF
--- a/doc/release.rst
+++ b/doc/release.rst
@@ -7,6 +7,19 @@ Release 0.12.0
 
 * [#473] A new FastxRecord class that can be instantiated from class and
   modified in-place. Replaces PersistentFastqProxy.
+* wrap htslib 1.5
+* SAM/BAM/CRAM headers are now managed by a separate AlignmentHeader
+  class.
+* AlignmentFile.header.as_dict() returns an ordered dictionary.
+* Use "stop" instead of "end" to ensure consistency to
+  VariantFile. The end designations have been kept for backwards
+  compatibility.
+
+Backwards incompatible changes:
+* AlignmentFile.header now returns an AlignmentHeader object. Use
+  AlignmentFile.header.as_dict() to get the dictionary as previously.
+* AlignmentFile.text is now AlignmentFile.header.__str__()
+* AlignmentFile, FastaFile now raise IOError.
 
 
 Release 0.11.2.2

--- a/pysam/libcalignedsegment.pxd
+++ b/pysam/libcalignedsegment.pxd
@@ -79,7 +79,7 @@ cdef class PileupRead:
     cdef uint32_t _is_refskip
 
 # factory methods
-cdef makeAlignedSegment(bam1_t * src, AlignmentHeader header)
-cdef makePileupColumn(bam_pileup1_t ** plp, int tid, int pos, int n_pu, AlignmentHeader header)
-cdef makePileupRead(bam_pileup1_t * src, AlignmentHeader header)
+cdef AlignedSegment makeAlignedSegment(bam1_t * src, AlignmentHeader header)
+cdef PileupColumn makePileupColumn(bam_pileup1_t ** plp, int tid, int pos, int n_pu, AlignmentHeader header)
+cdef PileupRead makePileupRead(bam_pileup1_t * src, AlignmentHeader header)
 cdef uint32_t get_alignment_length(bam1_t * src)

--- a/pysam/libcalignedsegment.pxd
+++ b/pysam/libcalignedsegment.pxd
@@ -37,7 +37,7 @@ cdef class AlignedSegment:
     cdef bam1_t * _delegate
 
     # the header that a read is associated with
-    cdef AlignmentHeader header
+    cdef readonly AlignmentHeader header
 
     # caching of array properties for quick access
     cdef object cache_query_qualities

--- a/pysam/libcalignedsegment.pxd
+++ b/pysam/libcalignedsegment.pxd
@@ -26,7 +26,7 @@ cdef extern from "htslib_util.h":
     void pysam_update_flag(bam1_t * b, uint16_t v, uint16_t flag)
 
 
-from pysam.libcalignmentfile cimport AlignmentFile
+from pysam.libcalignmentfile cimport AlignmentFile, AlignmentHeader
 ctypedef AlignmentFile AlignmentFile_t
 
 
@@ -36,8 +36,8 @@ cdef class AlignedSegment:
     # object that this AlignedSegment represents
     cdef bam1_t * _delegate
 
-    # the file from which this AlignedSegment originates (can be None)
-    cdef AlignmentFile _alignment_file
+    # the header that a read is associated with
+    cdef AlignmentHeader header
 
     # caching of array properties for quick access
     cdef object cache_query_qualities
@@ -57,7 +57,7 @@ cdef class AlignedSegment:
     cpdef has_tag(self, tag)
 
     # returns a valid sam alignment string
-    cpdef tostring(self, AlignmentFile_t handle)
+    cpdef tostring(self, htsfile=*)
 
 
 cdef class PileupColumn:
@@ -65,7 +65,7 @@ cdef class PileupColumn:
     cdef int tid
     cdef int pos
     cdef int n_pu
-    cdef AlignmentFile _alignment_file
+    cdef AlignmentHeader header
 
 
 cdef class PileupRead:
@@ -78,8 +78,8 @@ cdef class PileupRead:
     cdef uint32_t _is_tail
     cdef uint32_t _is_refskip
 
-# factor methods
-cdef makeAlignedSegment(bam1_t * src, AlignmentFile alignment_file)
-cdef makePileupColumn(bam_pileup1_t ** plp, int tid, int pos, int n_pu, AlignmentFile alignment_file)
-cdef makePileupRead(bam_pileup1_t * src, AlignmentFile alignment_file)
+# factory methods
+cdef makeAlignedSegment(bam1_t * src, AlignmentHeader header)
+cdef makePileupColumn(bam_pileup1_t ** plp, int tid, int pos, int n_pu, AlignmentHeader header)
+cdef makePileupRead(bam_pileup1_t * src, AlignmentHeader header)
 cdef uint32_t get_alignment_length(bam1_t * src)

--- a/pysam/libcalignedsegment.pyx
+++ b/pysam/libcalignedsegment.pyx
@@ -932,6 +932,16 @@ cdef class AlignedSegment:
         """:term:`reference` name"""
         def __get__(self):
             return self.header.get_reference_name(self._delegate.core.tid)
+        def __set__(self, reference):
+            cdef int tid
+            if reference is None:
+                self._delegate.core.tid = -1
+            else:
+                tid = self.header.get_tid(reference)
+                if tid < 0:
+                    raise ValueError("reference {} does not exist in header".format(
+                        reference))
+                self._delegate.core.tid = tid
 
     property reference_id:
         """:term:`reference` ID
@@ -944,8 +954,13 @@ cdef class AlignedSegment:
             :meth:`get_reference_name()`
 
         """
-        def __get__(self): return self._delegate.core.tid
-        def __set__(self, tid): self._delegate.core.tid = tid
+        def __get__(self):
+            return self._delegate.core.tid
+        def __set__(self, tid):
+            if tid != -1 and not self.header.is_valid_tid(tid):
+                raise ValueError("reference id {} does not exist in header".format(
+                    tid))
+            self._delegate.core.tid = tid
 
     property reference_start:
         """0-based leftmost coordinate"""

--- a/pysam/libcalignmentfile.pxd
+++ b/pysam/libcalignmentfile.pxd
@@ -80,7 +80,7 @@ cdef class IteratorRow:
     cdef bam1_t * b
     cdef AlignmentFile samfile
     cdef htsFile * htsfile
-    cdef readonly AlignmentHeader header
+    cdef AlignmentHeader header
     cdef int owns_samfile
 
 
@@ -125,7 +125,7 @@ cdef class IteratorColumn:
     cdef bam_pileup1_t * plp
     cdef bam_plp_t pileup_iter
     cdef __iterdata iterdata
-    cdef readonly AlignmentFile samfile
+    cdef AlignmentFile samfile
     cdef Fastafile fastafile
     cdef stepper
     cdef int max_depth
@@ -156,6 +156,6 @@ cdef class IteratorColumnAllRefs(IteratorColumn):
 cdef class IndexedReads:
     cdef AlignmentFile samfile
     cdef htsFile * htsfile
-    cdef readonly object index
+    cdef object index
     cdef int owns_samfile
-    cdef readonly AlignmentHeader header
+    cdef AlignmentHeader header

--- a/pysam/libcalignmentfile.pxd
+++ b/pysam/libcalignmentfile.pxd
@@ -36,13 +36,16 @@ ctypedef struct __iterdata:
     int seq_len
 
 
+cdef class AlignmentHeader(object):
+    cdef bam_hdr_t *ptr
+
+
 cdef class AlignmentFile(HTSFile):
     cdef readonly object reference_filename
+    cdef readonly AlignmentHeader header
 
     # pointer to index
     cdef hts_idx_t *index
-    # header structure
-    cdef bam_hdr_t * header
 
     # current read within iteration
     cdef bam1_t * b
@@ -77,7 +80,7 @@ cdef class IteratorRow:
     cdef bam1_t * b
     cdef AlignmentFile samfile
     cdef htsFile * htsfile
-    cdef bam_hdr_t * header
+    cdef readonly AlignmentHeader header
     cdef int owns_samfile
 
 
@@ -86,11 +89,13 @@ cdef class IteratorRowRegion(IteratorRow):
     cdef bam1_t * getCurrent(self)
     cdef int cnext(self)
 
+
 cdef class IteratorRowHead(IteratorRow):
     cdef int max_rows
     cdef int current_row
     cdef bam1_t * getCurrent(self)
     cdef int cnext(self)
+
 
 cdef class IteratorRowAll(IteratorRow):
     cdef bam1_t * getCurrent(self)
@@ -120,7 +125,7 @@ cdef class IteratorColumn:
     cdef bam_pileup1_t * plp
     cdef bam_plp_t pileup_iter
     cdef __iterdata iterdata
-    cdef AlignmentFile samfile
+    cdef readonly AlignmentFile samfile
     cdef Fastafile fastafile
     cdef stepper
     cdef int max_depth
@@ -151,6 +156,6 @@ cdef class IteratorColumnAllRefs(IteratorColumn):
 cdef class IndexedReads:
     cdef AlignmentFile samfile
     cdef htsFile * htsfile
-    cdef index
+    cdef readonly object index
     cdef int owns_samfile
-    cdef bam_hdr_t * header
+    cdef readonly AlignmentHeader header

--- a/pysam/libcalignmentfile.pyx
+++ b/pysam/libcalignmentfile.pyx
@@ -784,8 +784,8 @@ cdef class AlignmentFile(HTSFile):
 
             self.htsfile = self._open_htsfile()
 
-            if not self.htsfile:
-                raise IOError("could not open htsfile for writing")
+            if self.htsfile == NULL:
+                raise OSError("could not open file `{}` (mode='{}')".format(filename, mode))
             
             # set filename with reference sequences. If no filename
             # is given, the CRAM reference arrays will be built from

--- a/pysam/libcalignmentfile.pyx
+++ b/pysam/libcalignmentfile.pyx
@@ -8,6 +8,8 @@
 #
 # class AlignmentFile   read/write access to SAM/BAM/CRAM formatted files
 #
+# class AlignmentHeader manage SAM/BAM/CRAM header data
+#
 # class IndexedReads    index a SAM/BAM/CRAM file by query name while keeping
 #                       the original sort order intact
 #
@@ -75,6 +77,13 @@ else:
 
 cimport cython
 
+__all__ = [
+    "AlignmentFile",
+    "AlignmentHeader",
+    "IteratorRow",
+    "IteratorColumn",
+    "IndexedReads"]
+
 ########################################################
 ## global variables
 # maximum genomic coordinace
@@ -141,21 +150,38 @@ def build_header_line(fields, record):
 
     return "\t".join(line)
 
-cdef bam_hdr_t * build_header_from_dict(new_header):
-    '''return a new header built from a dictionary in `new_header`.
+
+cdef AlignmentHeader makeAlignmentHeader(bam_hdr_t *hdr):
+    if not hdr:
+        raise ValueError('cannot create AlignmentHeader')
+
+    # check: is AlignmetHeader.__cinit__ called?
+    cdef AlignmentHeader header = AlignmentHeader.__new__(AlignmentHeader)
+    header.ptr = hdr
+
+    return header
+
+
+# the following should be class-method for VariantHeader, but cdef @classmethods
+# are not implemented in cython.
+cdef AlignmentHeader makeAlignmentHeader_from_dict(header_dict):
+    '''build a new header built from a dictionary in `header_dict`.
 
     This method inserts the text field, target_name and target_len.
     '''
-    cdef list lines = []
 
-    # create new header and copy old data
-    cdef bam_hdr_t * dest = bam_hdr_init()
+    # create new header
+    cdef AlignmentHeader new_header = AlignmentHeader.__new__(AlignmentHeader)
+    new_header.ptr = bam_hdr_init()
+    cdef bam_hdr_t * dest = new_header.ptr
+
+    cdef list lines = []
 
     # first: defined tags
     for record in VALID_HEADERS:
-        if record in new_header:
+        if record in header_dict:
             ttype = VALID_HEADER_TYPES[record]
-            data = new_header[record]
+            data = header_dict[record]
             if type(data) != type(ttype()):
                 raise ValueError(
                     "invalid type for record %s: %s, expected %s" %
@@ -163,16 +189,17 @@ cdef bam_hdr_t * build_header_from_dict(new_header):
             if type(data) is dict:
                 lines.append(build_header_line(data, record))
             else:
-                for fields in new_header[record]:
+                for fields in header_dict[record]:
                     lines.append(build_header_line(fields, record))
 
     # then: user tags (lower case), sorted alphabetically
-    for record, data in sorted(new_header.items()):
-        if record in VALID_HEADERS: continue
+    for record, data in sorted(header_dict.items()):
+        if record in VALID_HEADERS:
+            continue
         if type(data) is dict:
             lines.append(build_header_line(data, record))
         else:
-            for fields in new_header[record]:
+            for fields in header_dict[record]:
                 lines.append(build_header_line(fields, record))
 
     text = "\n".join(lines) + "\n"
@@ -186,10 +213,11 @@ cdef bam_hdr_t * build_header_from_dict(new_header):
     strncpy(dest.text, btext, dest.l_text)
 
     cdef bytes bseqname
-    # collect targets
-    if "SQ" in new_header:
+    
+    # collect sequences
+    if "SQ" in header_dict:
         seqs = []
-        for fields in new_header["SQ"]:
+        for fields in header_dict["SQ"]:
             try:
                 seqs.append( (fields["SN"], fields["LN"] ) )
             except KeyError:
@@ -213,19 +241,25 @@ cdef bam_hdr_t * build_header_from_dict(new_header):
             strncpy(dest.target_name[x], bseqname,
                     len(seqname) + 1)
             dest.target_len[x] = seqlen
+            
+    return new_header
 
-    return dest
 
-
-cdef bam_hdr_t * build_header_from_list(reference_names,
-                                        reference_lengths,
-                                        add_sq_text=True,
-                                        text=None):
-
+# the following should be class-method for VariantHeader, but cdef @classmethods
+# are not implemented in cython.
+cdef AlignmentHeader makeAlignmentHeader_from_list(reference_names,
+                                                   reference_lengths,
+                                                   add_sq_text=True,
+                                                   text=None):
+    """build header from list of reference names and lengths.
+    """
+    # create new header
+    cdef AlignmentHeader new_header = AlignmentHeader.__new__(AlignmentHeader)
+    new_header.ptr = bam_hdr_init()
+    cdef bam_hdr_t * dest = new_header.ptr
+    
     assert len(reference_names) == len(reference_lengths), \
         "unequal names and lengths of reference sequences"
-
-    cdef bam_hdr_t * dest = bam_hdr_init()
 
     # allocate and fill header
     reference_names = [force_bytes(ref) for ref in reference_names]
@@ -273,7 +307,193 @@ cdef bam_hdr_t * build_header_from_list(reference_names,
             raise MemoryError("could not allocate {} bytes".format(strlen(ctext), sizeof(char)))
         memcpy(dest.text, ctext, strlen(ctext))
 
-    return dest
+    return new_header
+
+
+cdef class AlignmentHeader(object):
+    """header information for a :class:`AlignmentFile` object"""
+
+    # See makeVariantHeader for C constructor
+    def __cinit__(self):
+        self.ptr = NULL
+
+    # Python constructor
+    def __init__(self):
+        self.ptr = bam_hdr_init()
+        if not self.ptr:
+            raise ValueError('cannot create AlignmentHeader')
+
+    def __dealloc__(self):
+        if self.ptr:
+            bam_hdr_destroy(self.ptr)
+            self.ptr = NULL
+
+    def __bool__(self):
+        return self.ptr != NULL
+
+    def copy(self):
+        return makeAlignmentHeader(bam_hdr_dup(self.ptr))
+
+    def clear(self):
+        """clear header.
+
+        Note that this will invalidate all objectst that reference the header.
+        """
+        if self.ptr:
+            bam_hdr_destroy(self.ptr)
+            self.ptr = NULL
+    
+    property nreferences:
+        """"int with the number of :term:`reference` sequences in the file.
+
+        This is a read-only attribute."""
+        def __get__(self):
+            if self.ptr:
+                return self.ptr.n_targets
+            else:
+                return 0
+
+    property references:
+        """tuple with the names of :term:`reference` sequences. This is a
+        read-only attribute"""
+        def __get__(self):
+            t = []
+            if self.ptr:
+                for x from 0 <= x < self.ptr.n_targets:
+                    t.append(charptr_to_str(self.ptr.target_name[x]))
+            return tuple(t)
+
+    property lengths:
+        """tuple of the lengths of the :term:`reference` sequences. This is a
+        read-only attribute. The lengths are in the same order as
+        :attr:`pysam.AlignmentFile.references`
+        """
+        def __get__(self):
+            t = []
+            if self.ptr:
+                for x from 0 <= x < self.ptr.n_targets:
+                    t.append(self.ptr.target_len[x])
+            return tuple(t)
+    
+    def as_dict(self):
+        """return two-level dictionary with header information from the file.
+
+        The first level contains the record (``HD``, ``SQ``, etc) and
+        the second level contains the fields (``VN``, ``LN``, etc).
+
+        The parser is validating and will raise an AssertionError if
+        if encounters any record or field tags that are not part of
+        the SAM specification. Use the
+        :attr:`pysam.AlignmentFile.text` attribute to get the unparsed
+        header.
+
+        The parsing follows the SAM format specification with the
+        exception of the ``CL`` field. This option will consume the
+        rest of a header line irrespective of any additional fields.
+        This behaviour has been added to accommodate command line
+        options that contain characters that are not valid field
+        separators.
+
+        """
+        result = collections.OrderedDict()
+
+        if self.ptr != NULL:
+            # convert to python string
+            t = self.__str__()
+
+            for line in t.split("\n"):
+                if not line.strip(): continue
+                assert line.startswith("@"), \
+                    "header line without '@': '%s'" % line
+                fields = line[1:].split("\t")
+                record = fields[0]
+                assert record in VALID_HEADER_TYPES, \
+                    "header line with invalid type '%s': '%s'" % (record, line)
+
+                # treat comments
+                if record == "CO":
+                    if record not in result:
+                        result[record] = []
+                    result[record].append("\t".join( fields[1:]))
+                    continue
+                # the following is clumsy as generators do not work?
+                x = {}
+
+                for idx, field in enumerate(fields[1:]):
+                    if ":" not in field:
+                        raise ValueError("malformatted header: no ':' in field" )
+                    key, value = field.split(":", 1)
+                    if key in ("CL",):
+                        # special treatment for command line
+                        # statements (CL). These might contain
+                        # characters that are non-conformant with
+                        # the valid field separators in the SAM
+                        # header. Thus, in contravention to the
+                        # SAM API, consume the rest of the line.
+                        key, value = "\t".join(fields[idx+1:]).split(":", 1)
+                        x[key] = KNOWN_HEADER_FIELDS[record][key](value)
+                        break
+
+                    # interpret type of known header record tags, default to str
+                    x[key] = KNOWN_HEADER_FIELDS[record].get(key, str)(value)
+
+                if VALID_HEADER_TYPES[record] == dict:
+                    if record in result:
+                        raise ValueError(
+                            "multiple '%s' lines are not permitted" % record)
+
+                    result[record] = x
+                elif VALID_HEADER_TYPES[record] == list:
+                    if record not in result: result[record] = []
+                    result[record].append(x)
+
+            # if there are no SQ lines in the header, add the
+            # reference names from the information in the bam
+            # file.
+            #
+            # Background: c-samtools keeps the textual part of the
+            # header separate from the list of reference names and
+            # lengths. Thus, if a header contains only SQ lines,
+            # the SQ information is not part of the textual header
+            # and thus are missing from the output. See issue 84.
+            if "SQ" not in result:
+                sq = []
+                for ref, length in zip(self.references, self.lengths):
+                    sq.append({'LN': length, 'SN': ref })
+                result["SQ"] = sq
+
+        return result
+
+    def get_reference_name(self, tid):
+        if not 0 <= tid < self.ptr.n_targets:
+            raise ValueError("reference_id %i out of range 0<=tid<%i" %
+                             (tid, self.ptr.n_targets))
+        return charptr_to_str(self.ptr.target_name[tid])
+
+    def is_valid_tid(self, int tid):
+        """
+        return True if the numerical :term:`tid` is valid; False otherwise.
+        """
+        return 0 <= tid < self.ptr.n_targets
+
+    def get_tid(self, reference):
+        """
+        return the numerical :term:`tid` corresponding to
+        :term:`reference`
+
+        returns -1 if reference is not known.
+        """
+        reference = force_bytes(reference)
+        return bam_name2id(self.ptr, reference)
+        
+    def __str__(self):
+        '''string with the full contents of the :term:`sam file` header as a
+        string.
+
+        See :attr:`pysam.AlignmentFile.header` to get a parsed
+        representation of the header.
+        '''
+        return from_string_and_size(self.ptr.text, self.ptr.l_text)
 
 
 cdef class AlignmentFile(HTSFile):
@@ -482,7 +702,8 @@ cdef class AlignmentFile(HTSFile):
         cdef char *creference_filename = NULL
         cdef char *cindexname = NULL
         cdef char *cmode = NULL
-
+        cdef bam_hdr_t * hdr = NULL
+        
         # for backwards compatibility:
         if referencenames is not None:
             reference_names = referencenames
@@ -550,16 +771,16 @@ cdef class AlignmentFile(HTSFile):
 
             # header structure (used for writing)
             if template:
-                self.header = bam_hdr_dup(template.header)
+                self.header = template.header.copy()
             elif header:
-                self.header = build_header_from_dict(header)
+                self.header = makeAlignmentHeader_from_dict(header)
             else:
                 assert reference_names and reference_lengths, \
                     ("either supply options `template`, `header` "
                      "or  both `reference_names` and `reference_lengths` "
                      "for writing")
                 # build header from a target names and lengths
-                self.header = build_header_from_list(
+                self.header = makeAlignmentHeader_from_list(
                     reference_names,
                     reference_lengths,
                     add_sq_text=add_sq_text,
@@ -576,8 +797,9 @@ cdef class AlignmentFile(HTSFile):
 
             # write header to htsfile
             if "b" in mode or "c" in mode or "h" in mode:
+                hdr = self.header.ptr
                 with nogil:
-                    sam_hdr_write(self.htsfile, self.header)
+                    sam_hdr_write(self.htsfile, hdr)
 
         elif mode[0] == "r":
             # open file for reading
@@ -589,38 +811,42 @@ cdef class AlignmentFile(HTSFile):
             if self.htsfile == NULL:
                 raise ValueError(
                     "could not open file (mode='%s') - "
-                    "is it SAM/BAM format?" % mode)
+                    "is it SAM/BAM/CRAM format?" % mode)
 
             if self.htsfile.format.category != sequence_data:
                 raise ValueError("file does not contain alignment data")
 
             self.check_truncation(ignore_truncation)
 
-            # bam files require a valid header
+            # bam/cram files require a valid header
             if self.is_bam or self.is_cram:
                 with nogil:
-                    self.header = sam_hdr_read(self.htsfile)
-                if self.header == NULL:
+                    hdr = sam_hdr_read(self.htsfile)
+                if hdr == NULL:
                     raise ValueError(
-                        "file does not have valid header (mode='%s') "
-                        "- is it BAM format?" % mode )
+                        "file does not have a valid header (mode='%s') "
+                        "- is it BAM/CRAM format?" % mode)
+                self.header = makeAlignmentHeader(hdr)
             else:
-                # in sam files a header is optional, but requires
-                # reference names and lengths
+                # in sam files a header is optional. If not given,
+                # user my provide reference names and lengths to built
+                # an on-the-fly header.
                 if reference_names and reference_lengths:
-                    self.header = build_header_from_list(
+                    # build header from a target names and lengths
+                    self.header = makeAlignmentHeader_from_list(
                         reference_names,
                         reference_lengths,
                         add_sq_text=add_sq_text,
                         text=text)
                 else:
                     with nogil:
-                        self.header = sam_hdr_read(self.htsfile)
-                    if self.header == NULL:
+                        hdr = sam_hdr_read(self.htsfile)
+                    if hdr == NULL:
                         raise ValueError(
-                            "file does not have valid header (mode='%s'), "
+                            "SAM? file does not have a valid header (mode='%s'), "
                             "please provide reference_names and reference_lengths")
-
+                    self.header = makeAlignmentHeader(hdr)
+                
             # set filename with reference sequences
             if self.is_cram and reference_filename:
                 creference_filename = self.reference_filename
@@ -628,7 +854,7 @@ cdef class AlignmentFile(HTSFile):
                             CRAM_OPT_REFERENCE,
                             creference_filename)
 
-            if check_sq and self.header.n_targets == 0:
+            if check_sq and self.header.nreferences == 0:
                 raise ValueError(
                     ("file has no sequences defined (mode='%s') - "
                      "is it SAM/BAM format? Consider opening with "
@@ -697,35 +923,6 @@ cdef class AlignmentFile(HTSFile):
             # save start of data section
             if not self.is_stream:
                 self.start_offset = self.tell()
-
-    def is_valid_tid(self, tid):
-        """
-        return True if the numerical :term:`tid` is valid; False otherwise.
-        """
-        return 0 <= tid < self.header.n_targets
-
-    def get_tid(self, reference):
-        """
-        return the numerical :term:`tid` corresponding to
-        :term:`reference`
-
-        returns -1 if reference is not known.
-        """
-        if not self.is_open:
-            raise ValueError("I/O operation on closed file")
-        reference = force_bytes(reference)
-        return bam_name2id(self.header, reference)
-
-    def get_reference_name(self, tid):
-        """
-        return :term:`reference` name corresponding to numerical :term:`tid`
-        """
-        if not self.is_open:
-            raise ValueError("I/O operation on closed file")
-        if not 0 <= tid < self.header.n_targets:
-            raise ValueError("reference_id %i out of range 0<=tid<%i" %
-                             (tid, self.header.n_targets))
-        return charptr_to_str(self.header.target_name[tid])
 
     def fetch(self,
               contig=None,
@@ -1289,9 +1486,7 @@ cdef class AlignmentFile(HTSFile):
             hts_idx_destroy(self.index)
             self.index = NULL
 
-        if self.header != NULL:
-            bam_hdr_destroy(self.header)
-            self.header = NULL
+        self.header = None
 
         if ret < 0:
             global errno
@@ -1311,9 +1506,7 @@ cdef class AlignmentFile(HTSFile):
             hts_idx_destroy(self.index)
             self.index = NULL
 
-        if self.header != NULL:
-            bam_hdr_destroy(self.header)
-            self.header = NULL
+        self.header = None
 
         if self.b:
             bam_destroy1(self.b)
@@ -1348,7 +1541,7 @@ cdef class AlignmentFile(HTSFile):
 
         with nogil:
             ret = sam_write1(self.htsfile,
-                             self.header,
+                             self.header.ptr,
                              read._delegate)
 
         # kbj: Still need to raise an exception with except -1. Otherwise
@@ -1373,38 +1566,6 @@ cdef class AlignmentFile(HTSFile):
     ###############################################################
     ## properties
     ###############################################################
-    property nreferences:
-        """"int with the number of :term:`reference` sequences in the file.
-        This is a read-only attribute."""
-        def __get__(self):
-            if not self.is_open:
-                raise ValueError("I/O operation on closed file")
-            return self.header.n_targets
-
-    property references:
-        """tuple with the names of :term:`reference` sequences. This is a
-        read-only attribute"""
-        def __get__(self):
-            if not self.is_open: raise ValueError( "I/O operation on closed file" )
-            t = []
-            for x from 0 <= x < self.header.n_targets:
-                t.append(charptr_to_str(self.header.target_name[x]))
-            return tuple(t)
-
-    property lengths:
-        """tuple of the lengths of the :term:`reference` sequences. This is a
-        read-only attribute. The lengths are in the same order as
-        :attr:`pysam.AlignmentFile.references`
-
-        """
-        def __get__(self):
-            if not self.is_open:
-                raise ValueError("I/O operation on closed file")
-            t = []
-            for x from 0 <= x < self.header.n_targets:
-                t.append(self.header.target_len[x])
-            return tuple(t)
-
     property mapped:
         """int with total number of mapped alignments according to the
         statistics recorded in the index. This is a read-only
@@ -1415,7 +1576,7 @@ cdef class AlignmentFile(HTSFile):
             cdef int tid
             cdef uint64_t total = 0
             cdef uint64_t mapped, unmapped
-            for tid from 0 <= tid < self.header.n_targets:
+            for tid from 0 <= tid < self.header.nreferences:
                 with nogil:
                     hts_idx_get_stat(self.index, tid, &mapped, &unmapped)
                 total += mapped
@@ -1431,7 +1592,7 @@ cdef class AlignmentFile(HTSFile):
             cdef int tid
             cdef uint64_t total = hts_idx_get_n_no_coor(self.index)
             cdef uint64_t mapped, unmapped
-            for tid from 0 <= tid < self.header.n_targets:
+            for tid from 0 <= tid < self.header.nreferences:
                 with nogil:
                     hts_idx_get_stat(self.index, tid, &mapped, &unmapped)
                 total += unmapped
@@ -1448,115 +1609,6 @@ cdef class AlignmentFile(HTSFile):
                 n = hts_idx_get_n_no_coor(self.index)
             return n
 
-    property text:
-        '''string with the full contents of the :term:`sam file` header as a
-        string.
-
-        This is a read-only attribute.
-
-        See :attr:`pysam.AlignmentFile.header` to get a parsed
-        representation of the header.
-        '''
-        def __get__(self):
-            if not self.is_open:
-                raise ValueError( "I/O operation on closed file" )
-            return from_string_and_size(self.header.text, self.header.l_text)
-
-    property header:
-        """two-level dictionay with header information from the file.
-
-        This is a read-only attribute.
-
-        The first level contains the record (``HD``, ``SQ``, etc) and
-        the second level contains the fields (``VN``, ``LN``, etc).
-
-        The parser is validating and will raise an AssertionError if
-        if encounters any record or field tags that are not part of
-        the SAM specification. Use the
-        :attr:`pysam.AlignmentFile.text` attribute to get the unparsed
-        header.
-
-        The parsing follows the SAM format specification with the
-        exception of the ``CL`` field. This option will consume the
-        rest of a header line irrespective of any additional fields.
-        This behaviour has been added to accommodate command line
-        options that contain characters that are not valid field
-        separators.
-
-        """
-        def __get__(self):
-            if not self.is_open:
-                raise ValueError( "I/O operation on closed file" )
-
-            result = {}
-
-            if self.header.text != NULL:
-                # convert to python string (note: call self.text to
-                # create 0-terminated string)
-                t = self.text
-                for line in t.split("\n"):
-                    if not line.strip(): continue
-                    assert line.startswith("@"), \
-                        "header line without '@': '%s'" % line
-                    fields = line[1:].split("\t")
-                    record = fields[0]
-                    assert record in VALID_HEADER_TYPES, \
-                        "header line with invalid type '%s': '%s'" % (record, line)
-
-                    # treat comments
-                    if record == "CO":
-                        if record not in result:
-                            result[record] = []
-                        result[record].append("\t".join( fields[1:]))
-                        continue
-                    # the following is clumsy as generators do not work?
-                    x = {}
-
-                    for idx, field in enumerate(fields[1:]):
-                        if ":" not in field:
-                            raise ValueError("malformatted header: no ':' in field" )
-                        key, value = field.split(":", 1)
-                        if key in ("CL",):
-                            # special treatment for command line
-                            # statements (CL). These might contain
-                            # characters that are non-conformant with
-                            # the valid field separators in the SAM
-                            # header. Thus, in contravention to the
-                            # SAM API, consume the rest of the line.
-                            key, value = "\t".join(fields[idx+1:]).split(":", 1)
-                            x[key] = KNOWN_HEADER_FIELDS[record][key](value)
-                            break
-
-                        # interpret type of known header record tags, default to str
-                        x[key] = KNOWN_HEADER_FIELDS[record].get(key, str)(value)
-
-                    if VALID_HEADER_TYPES[record] == dict:
-                        if record in result:
-                            raise ValueError(
-                                "multiple '%s' lines are not permitted" % record)
-
-                        result[record] = x
-                    elif VALID_HEADER_TYPES[record] == list:
-                        if record not in result: result[record] = []
-                        result[record].append(x)
-
-                # if there are no SQ lines in the header, add the
-                # reference names from the information in the bam
-                # file.
-                #
-                # Background: c-samtools keeps the textual part of the
-                # header separate from the list of reference names and
-                # lengths. Thus, if a header contains only SQ lines,
-                # the SQ information is not part of the textual header
-                # and thus are missing from the output. See issue 84.
-                if "SQ" not in result:
-                    sq = []
-                    for ref, length in zip(self.references, self.lengths):
-                        sq.append({'LN': length, 'SN': ref })
-                    result["SQ"] = sq
-
-            return result
-
     ###############################################################
     ## file-object like iterator access
     ## note: concurrent access will cause errors (see IteratorRow
@@ -1566,7 +1618,7 @@ cdef class AlignmentFile(HTSFile):
         if not self.is_open:
             raise ValueError("I/O operation on closed file")
 
-        if not self.is_bam and self.header.n_targets == 0:
+        if not self.is_bam and self.header.nreferences == 0:
             raise NotImplementedError(
                 "can not iterate over samfile without header")
         return self
@@ -1579,20 +1631,81 @@ cdef class AlignmentFile(HTSFile):
         cversion of iterator. Used by :class:`pysam.AlignmentFile.IteratorColumn`.
         '''
         cdef int ret
+        cdef bam_hdr_t * hdr = self.header.ptr
         with nogil:
             ret = sam_read1(self.htsfile,
-                            self.header,
+                            hdr,
                             self.b)
         return ret
 
     def __next__(self):
         cdef int ret = self.cnext()
         if (ret >= 0):
-            return makeAlignedSegment(self.b, self)
+            return makeAlignedSegment(self.b, self.header)
         elif ret == -2:
             raise IOError('truncated file')
         else:
             raise StopIteration
+
+    ###########################################################################
+    # methods/properties referencing the header. These are mostly for backwards
+    # compatibility for pysam < 0.12
+    def is_valid_tid(self, int tid):
+        """
+        return True if the numerical :term:`tid` is valid; False otherwise.
+        """
+        if self.header is None:
+            raise ValueError("header not available in closed files")
+        return self.header.is_valid_tid(tid)
+
+    def get_tid(self, reference):
+        """
+        return the numerical :term:`tid` corresponding to
+        :term:`reference`
+
+        returns -1 if reference is not known.
+        """
+        if self.header is None:
+            raise ValueError("header not available in closed files")
+        return self.header.get_tid(reference)
+
+    def get_reference_name(self, tid):
+        """
+        return :term:`reference` name corresponding to numerical :term:`tid`
+        """
+        if self.header is None:
+            raise ValueError("header not available in closed files")
+        return self.header.get_reference_name(tid)
+    
+    property nreferences:
+        """"int with the number of :term:`reference` sequences in the file.
+        This is a read-only attribute."""
+        def __get__(self):
+            if self.header:
+                return self.header.nreferences
+            else:
+                raise ValueError("header not available in closed files")
+
+    property references:
+        """tuple with the names of :term:`reference` sequences. This is a
+        read-only attribute"""
+        def __get__(self):
+            if self.header:
+                return self.header.references
+            else:
+                raise ValueError("header not available in closed files")
+
+    property lengths:
+        """tuple of the lengths of the :term:`reference` sequences. This is a
+        read-only attribute. The lengths are in the same order as
+        :attr:`pysam.AlignmentFile.references`
+
+        """
+        def __get__(self):
+            if self.header:
+                return self.header.lengths
+            else:
+                raise ValueError("header not available in closed files")
 
     # Compatibility functions for pysam < 0.8.3
     def gettid(self, reference):
@@ -1643,16 +1756,21 @@ cdef class IteratorRow:
         # reopen the file - note that this makes the iterator
         # slow and causes pileup to slow down significantly.
         if multiple_iterators:
+            
             cfilename = samfile.filename
             with nogil:
                 self.htsfile = hts_open(cfilename, 'r')
             assert self.htsfile != NULL
-            # read header - required for accurate positioning
-            # could a tell/seek work?
+
+            # need to advance in newly opened file to position after header
+            # better: use seek/tell?
             with nogil:
-                self.header = sam_hdr_read(self.htsfile)
-            assert self.header != NULL
+                hdr = sam_hdr_read(self.htsfile)
+            assert hdr != NULL
+            self.header = makeAlignmentHeader(hdr)
+
             self.owns_samfile = True
+            
             # options specific to CRAM files
             if samfile.is_cram and samfile.reference_filename:
                 creference_filename = samfile.reference_filename
@@ -1661,9 +1779,9 @@ cdef class IteratorRow:
                             creference_filename)
 
         else:
-            self.htsfile = self.samfile.htsfile
+            self.htsfile = samfile.htsfile
             self.owns_samfile = False
-            self.header = self.samfile.header
+            self.header = samfile.header
 
         self.retval = 0
 
@@ -1673,7 +1791,6 @@ cdef class IteratorRow:
         bam_destroy1(self.b)
         if self.owns_samfile:
             hts_close(self.htsfile)
-            bam_hdr_destroy(self.header)
 
 
 cdef class IteratorRowRegion(IteratorRow):
@@ -1724,7 +1841,7 @@ cdef class IteratorRowRegion(IteratorRow):
     def __next__(self):
         self.cnext()
         if self.retval >= 0:
-            return makeAlignedSegment(self.b, self.samfile)
+            return makeAlignedSegment(self.b, self.header)
         elif self.retval == -2:
             # Note: it is currently not the case that hts_iter_next
             # returns -2 for a truncated file.
@@ -1749,7 +1866,9 @@ cdef class IteratorRowHead(IteratorRow):
 
     """
 
-    def __init__(self, AlignmentFile samfile, int n,
+    def __init__(self,
+                 AlignmentFile samfile,
+                 int n,
                  int multiple_iterators=False):
 
         IteratorRow.__init__(self, samfile,
@@ -1767,9 +1886,10 @@ cdef class IteratorRowHead(IteratorRow):
     cdef int cnext(self):
         '''cversion of iterator. Used by IteratorColumn'''
         cdef int ret
+        cdef bam_hdr_t * hdr = self.header.ptr
         with nogil:
             ret = sam_read1(self.htsfile,
-                            self.samfile.header,
+                            hdr,
                             self.b)
         return ret
 
@@ -1780,7 +1900,7 @@ cdef class IteratorRowHead(IteratorRow):
         cdef int ret = self.cnext()
         if ret >= 0:
             self.current_row += 1
-            return makeAlignedSegment(self.b, self.samfile)
+            return makeAlignedSegment(self.b, self.header)
         elif ret == -2:
             raise IOError('truncated file')
         else:
@@ -1815,16 +1935,17 @@ cdef class IteratorRowAll(IteratorRow):
     cdef int cnext(self):
         '''cversion of iterator. Used by IteratorColumn'''
         cdef int ret
+        cdef bam_hdr_t * hdr = self.header.ptr
         with nogil:
             ret = sam_read1(self.htsfile,
-                            self.samfile.header,
+                            hdr,
                             self.b)
         return ret
 
     def __next__(self):
         cdef int ret = self.cnext()
         if ret >= 0:
-            return makeAlignedSegment(self.b, self.samfile)
+            return makeAlignedSegment(self.b, self.header)
         elif ret == -2:
             raise IOError('truncated file')
         else:
@@ -1885,7 +2006,7 @@ cdef class IteratorRowAllRefs(IteratorRow):
 
             # If current iterator is not exhausted, return aligned read
             if self.rowiter.retval > 0:
-                return makeAlignedSegment(self.rowiter.b, self.samfile)
+                return makeAlignedSegment(self.rowiter.b, self.header)
 
             self.tid += 1
 
@@ -1932,16 +2053,17 @@ cdef class IteratorRowSelection(IteratorRow):
         self.current_pos += 1
 
         cdef int ret
+        cdef bam_hdr_t * hdr = self.header.ptr
         with nogil:
             ret = sam_read1(self.htsfile,
-                            self.samfile.header,
+                            hdr,
                             self.b)
         return ret
 
     def __next__(self):
         cdef int ret = self.cnext()
         if (ret >= 0):
-            return makeAlignedSegment(self.b, self.samfile)
+            return makeAlignedSegment(self.b, self.header)
         elif (ret == -2):
             raise IOError('truncated file')
         else:
@@ -2164,7 +2286,7 @@ cdef class IteratorColumn:
         self.iterdata.iter = self.iter.iter
         self.iterdata.seq = NULL
         self.iterdata.tid = -1
-        self.iterdata.header = self.samfile.header
+        self.iterdata.header = self.samfile.header.ptr
 
         if self.fastafile is not None:
             self.iterdata.fastafile = self.fastafile.fastafile
@@ -2274,10 +2396,10 @@ cdef class IteratorColumnRegion(IteratorColumn):
                 if self.pos >= self.stop: raise StopIteration
 
             return makePileupColumn(&self.plp,
-                                   self.tid,
-                                   self.pos,
-                                   self.n_plp,
-                                   self.samfile)
+                                    self.tid,
+                                    self.pos,
+                                    self.n_plp,
+                                    self.samfile.header)
 
 
 cdef class IteratorColumnAllRefs(IteratorColumn):
@@ -2309,7 +2431,7 @@ cdef class IteratorColumnAllRefs(IteratorColumn):
                                         self.tid,
                                         self.pos,
                                         self.n_plp,
-                                        self.samfile)
+                                        self.samfile.header)
 
             # otherwise, proceed to next reference or stop
             self.tid += 1
@@ -2408,8 +2530,8 @@ cdef class IndexedReads:
         # makes sure that samfile stays alive as long as this
         # object is alive.
         self.samfile = samfile
-
-        assert samfile.is_bam, "can only IndexReads on bam files"
+        cdef bam_hdr_t * hdr = NULL
+        assert samfile.is_bam, "can only apply IndexReads on bam files"
 
         # multiple_iterators the file - note that this makes the iterator
         # slow and causes pileup to slow down significantly.
@@ -2418,13 +2540,18 @@ cdef class IndexedReads:
             with nogil:
                 self.htsfile = hts_open(cfilename, 'r')
             assert self.htsfile != NULL
-            # read header - required for accurate positioning
+
+            # need to advance in newly opened file to position after header
+            # better: use seek/tell?
             with nogil:
-                self.header = sam_hdr_read(self.htsfile)
+                hdr = sam_hdr_read(self.htsfile)
+            assert hdr != NULL
+            self.header = makeAlignmentHeader(hdr)
+
             self.owns_samfile = True
         else:
             self.htsfile = self.samfile.htsfile
-            self.header = self.samfile.header
+            self.header = samfile.header
             self.owns_samfile = False
 
     def build(self):
@@ -2432,20 +2559,20 @@ cdef class IndexedReads:
 
         self.index = collections.defaultdict(list)
 
-        # this method will start indexing from the current file
-        # position if you decide
+        # this method will start indexing from the current file position
         cdef int ret = 1
         cdef bam1_t * b = <bam1_t*>calloc(1, sizeof( bam1_t))
         if b == NULL:
-            raise ValueError("could not allocate {} bytes".format(sizeof(bam1_t)))
+            raise MemoryError("could not allocate {} bytes".format(sizeof(bam1_t)))
 
         cdef uint64_t pos
-
+        cdef bam_hdr_t * hdr = self.header.ptr
+        
         while ret > 0:
             with nogil:
                 pos = bgzf_tell(hts_get_bgzfp(self.htsfile))
                 ret = sam_read1(self.htsfile,
-                                self.samfile.header,
+                                hdr,
                                 b)
             if ret > 0:
                 qname = charptr_to_str(pysam_bam_get_qname(b))
@@ -2480,10 +2607,3 @@ cdef class IndexedReads:
     def __dealloc__(self):
         if self.owns_samfile:
             hts_close(self.htsfile)
-            bam_hdr_destroy(self.header)
-
-__all__ = [
-    "AlignmentFile",
-    "IteratorRow",
-    "IteratorColumn",
-    "IndexedReads"]

--- a/pysam/libcalignmentfile.pyx
+++ b/pysam/libcalignmentfile.pyx
@@ -802,6 +802,11 @@ cdef class AlignmentFile(HTSFile):
         if mode[0] == 'w':
             # open file for writing
 
+            if not (template or header or reference_names):
+                raise ValueError(
+                    "either supply options `template`, `header` or  both `reference_names` "
+                    "and `reference_lengths` for writing")
+            
             if template:
                 # header is copied, though at the moment not strictly
                 # necessary as AlignmentHeader is immutable.

--- a/pysam/libcalignmentfile.pyx
+++ b/pysam/libcalignmentfile.pyx
@@ -784,6 +784,9 @@ cdef class AlignmentFile(HTSFile):
 
             self.htsfile = self._open_htsfile()
 
+            if not self.htsfile:
+                raise IOError("could not open htsfile for writing")
+            
             # set filename with reference sequences. If no filename
             # is given, the CRAM reference arrays will be built from
             # the @SQ header in the header

--- a/pysam/libctabix.pyx
+++ b/pysam/libctabix.pyx
@@ -1176,6 +1176,7 @@ class tabix_generic_iterator:
     # python version - required for python 2.7
     def next(self):
         return self.__next__()
+    
 
 def tabix_iterator(infile, parser):
     """return an iterator over all entries in a file.

--- a/tests/AlignedSegment_test.py
+++ b/tests/AlignedSegment_test.py
@@ -5,8 +5,7 @@ import collections
 import copy
 import array
 
-from TestUtils import checkFieldEqual, BAM_DATADIR, WORKDIR
-
+from TestUtils import checkFieldEqual, BAM_DATADIR
 
 
 class ReadTest(unittest.TestCase):

--- a/tests/AlignedSegment_test.py
+++ b/tests/AlignedSegment_test.py
@@ -807,7 +807,7 @@ class TestCopy(ReadTest):
 
 class TestAsString(unittest.TestCase):
 
-    def testAsString(self):
+    def test_as_string_with_explicit_alignment_file(self):
         with open(os.path.join(BAM_DATADIR, "ex2.sam")) as samf:
             reference = [x[:-1] for x in samf if not x.startswith("@")]
 
@@ -816,6 +816,15 @@ class TestAsString(unittest.TestCase):
             for s, p in zip(reference, pysamf):
                 self.assertEqual(s, p.tostring(pysamf))
 
+    def test_as_string_without_alignment_file(self):
+        with open(os.path.join(BAM_DATADIR, "ex2.sam")) as samf:
+            reference = [x[:-1] for x in samf if not x.startswith("@")]
+
+        with pysam.AlignmentFile(
+            os.path.join(BAM_DATADIR, "ex2.bam"), "r") as pysamf:
+            for s, p in zip(reference, pysamf):
+                self.assertEqual(s, p.tostring())
+                
 
 class TestEnums(unittest.TestCase):
     

--- a/tests/AlignmentFile_test.py
+++ b/tests/AlignmentFile_test.py
@@ -2722,7 +2722,6 @@ class TestSanityCheckingBAM(unittest.TestCase):
 # class TestSanityCheckingSAM(TestSanityCheckingSAM):
 #     mode = "w"
 
-
 if __name__ == "__main__":
     # build data files
     print ("building data files")

--- a/tests/AlignmentFile_test.py
+++ b/tests/AlignmentFile_test.py
@@ -1212,10 +1212,9 @@ class TestTagParsing(unittest.TestCase):
     def makeRead(self):
         a = pysam.AlignedSegment()
         a.query_name = "read_12345"
-        a.reference_id = 0
+        a.reference_id = -1
         a.query_sequence = "ACGT" * 3
         a.flag = 0
-        a.reference_id = 0
         a.reference_start = 1
         a.mapping_quality = 20
         a.cigartuples = ((0, 10), (2, 1), (0, 25))
@@ -1754,7 +1753,9 @@ class TestDeNovoConstruction(unittest.TestCase):
 
     def setUp(self):
 
-        a = pysam.AlignedSegment()
+        header = pysam.AlignmentHeader(header_dict=self.header)
+        
+        a = pysam.AlignedSegment(header)
         a.query_name = "read_28833_29006_6945"
         a.query_sequence = "AGCTTAGCTAGCTACCTATATCTTGGTCTTGGCCG"
         a.flag = 99
@@ -1770,7 +1771,7 @@ class TestDeNovoConstruction(unittest.TestCase):
         a.tags = (("NM", 1),
                   ("RG", "L1"))
 
-        b = pysam.AlignedSegment()
+        b = pysam.AlignedSegment(header)
         b.query_name = "read_28701_28881_323b"
         b.query_sequence = "ACCTATATCTTGGCCTTGGCCGATGCGGCCTTGCA"
         b.flag = 147

--- a/tests/AlignmentFile_test.py
+++ b/tests/AlignmentFile_test.py
@@ -747,7 +747,7 @@ class TestIO(unittest.TestCase):
             return header
 
         header = load_bam()
-        self.assertTrue(header != None)
+        self.assertTrue(header)
         self.assertEqual(header.nreferences, 2)
         self.assertEqual(header.references, ("chr1", "chr2"))
 

--- a/tests/AlignmentFile_test.py
+++ b/tests/AlignmentFile_test.py
@@ -1216,29 +1216,30 @@ class TestTagParsing(unittest.TestCase):
         # todo: create tags
         return a
 
-    def testNegativeIntegers(self):
+    def test_negative_integers_can_be_recorded(self):
         x = -2
         aligned_read = self.makeRead()
         aligned_read.tags = [("XD", int(x))]
         self.assertEqual(aligned_read.opt('XD'), x)
-        # print (aligned_read.tags)
 
-    def testNegativeIntegers2(self):
+    def test_negative_integers_can_be_written_and_read(self):
         x = -2
         r = self.makeRead()
         r.tags = [("XD", x)]
-        outfile = pysam.AlignmentFile(
-            os.path.join(WORKDIR, "test.bam"),
-            "wb",
-            referencenames=("chr1",),
-            referencelengths = (1000,))
-        outfile.write(r)
-        outfile.close()
-        infile = pysam.AlignmentFile("test.bam")
-        r = next(infile)
+        
+        tmpfilename = get_temp_filename(".bam")
+        with pysam.AlignmentFile(
+                tmpfilename,
+                "wb",
+                referencenames=("chr1",),
+                referencelengths = (1000,)) as outf:
+            outf.write(r)
+
+        with pysam.AlignmentFile(tmpfilename) as inf:
+            r = next(inf)
+            
         self.assertEqual(r.tags, [("XD", x)])
-        infile.close()
-        os.unlink(os.path.join(WORKDIR, "test.bam"))
+        os.unlink(tmpfilename)
 
     def testCigarString(self):
         r = self.makeRead()

--- a/tests/AlignmentFile_test.py
+++ b/tests/AlignmentFile_test.py
@@ -883,6 +883,16 @@ class TestIO(unittest.TestCase):
             self.assertEqual(len(list(samfile.fetch('chr1',start=1000, end=2000))),
                              len(list(samfile.fetch(tid=0, start=1000, end=2000))))
 
+    def test_write_bam_to_unknown_path_fails(self):
+        '''see issue 116'''
+        input_filename = os.path.join(BAM_DATADIR, "ex1.bam")
+        with pysam.AlignmentFile(input_filename) as inf:
+            self.assertRaises(IOError,
+                              pysam.AlignmentFile,
+                              "missing_directory/new_file.bam",
+                              "wb",
+                              template=inf)
+        
 
 class TestAutoDetect(unittest.TestCase):
 

--- a/tests/TestUtils.py
+++ b/tests/TestUtils.py
@@ -192,6 +192,13 @@ def check_lines_equal(cls, a, b, sort=False, filter_f=None, msg=None):
 
 def get_temp_filename(suffix=""):
     caller_name = inspect.getouterframes(inspect.currentframe(), 2)[1][3]
+
+    if not os.path.exists(WORKDIR):
+        try:
+            os.makedirs(WORKDIR)
+        except OSError:
+            pass
+    
     f = tempfile.NamedTemporaryFile(
         prefix="tmp_{}_".format(caller_name),
         suffix=suffix,

--- a/tests/TestUtils.py
+++ b/tests/TestUtils.py
@@ -196,7 +196,7 @@ def get_temp_filename(suffix=""):
         prefix="tmp_{}_".format(caller_name),
         suffix=suffix,
         delete=False,
-        dir="tests")
+        dir=WORKDIR)
     f.close()
     return f.name
 

--- a/tests/samtools_test.py
+++ b/tests/samtools_test.py
@@ -147,15 +147,17 @@ class SamtoolsTest(unittest.TestCase):
         '''
         self.check_version()
 
-        if not os.path.exists(WORKDIR):
-            os.makedirs(WORKDIR)
+        self.workdir = os.path.join(WORKDIR, "samtools_test")
+        
+        if not os.path.exists(self.workdir):
+            os.makedirs(self.workdir)
 
         for f in self.requisites:
             shutil.copy(os.path.join(BAM_DATADIR, f),
-                        os.path.join(WORKDIR, f))
+                        os.path.join(self.workdir, f))
 
         self.savedir = os.getcwd()
-        os.chdir(WORKDIR)
+        os.chdir(self.workdir)
 
         return
 
@@ -267,8 +269,8 @@ class SamtoolsTest(unittest.TestCase):
             self.assertTrue(re.search(expected, usage_msg) is not None)
 
     def tearDown(self):
-        if os.path.exists(WORKDIR):
-            shutil.rmtree(WORKDIR)
+        if os.path.exists(self.workdir):
+            shutil.rmtree(self.workdir)
         os.chdir(self.savedir)
 
 


### PR DESCRIPTION
…#517

This PR separates header functionality into a separate class (AlignmentHeader, cf. VariantHeader) and propagates the information through to iterators and AlignedSegments. The benefit is that:

1. reference names can be looked up even after a file has been closed or is out-of-scope
2. reference names are always available and no need to look up via tid.

At the moment AlignmentHeaders are read-only objects, i.e. the header needs to be created before any derived AlignedSegments are being created. 

A few backwards incompatible changes are the consequence of this refactoring, most notable that AlignmentFile.header now returns AlignmentHeader and not a dictionary.
