### PR TITLE
fix missing symbols in libcsamtools and libcbcftools libraries

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -463,6 +463,7 @@ cutils = Extension(
 csamtools = Extension(
     "pysam.libcsamtools",
     [source_pattern % "samtools"] +
+    ["pysam/pysam_util.c"] +
     glob.glob(os.path.join("samtools", "*.pysam.c")) +
     htslib_sources +
     os_c_files,
@@ -484,7 +485,8 @@ cbcftools = Extension(
     library_dirs=["pysam"] + htslib_library_dirs,
     include_dirs=["bcftools", "pysam", "."] +
     include_os + htslib_include_dirs,
-    libraries=external_htslib_libraries + internal_htslib_libraries,
+    libraries=external_htslib_libraries + internal_htslib_libraries + \
+    [os.path.splitext("csamtools{}".format(suffix))[0]],
     language="c",
     extra_compile_args=extra_compile_args,
     define_macros=define_macros


### PR DESCRIPTION
Building on Ubuntu fails because a couple of the .so's wind up with
unresolved references to symbols found elsewhere in the tree.  Fix their
linkage so that they load cleanly.