### PR TITLE
skip usage() tests on autobuilders

### DIFF
--- a/tests/samtools_test.py
+++ b/tests/samtools_test.py
@@ -248,6 +248,7 @@ class SamtoolsTest(unittest.TestCase):
             self.check_statement(statement)
 
     @unittest.skipIf(sys.platform == "darwin", "not supported, pattern does not match")
+    @unittest.skipIf(not sys.stdin.isatty(), "skipping usage tests, stdin is not a tty")
     def testUsage(self):
         if self.executable == "bcftools":
             # bcftools usage messages end with exit(1)


### PR DESCRIPTION
The usage() functions check whether stdin is a tty before displaying usage
information.  Therefore, we should not test this code when running on an
autobuilder without a tty.

Clever allocation of a pty from within the test suite itself for purposes
of testing this path is left as an exercise for the reader.