### PR TITLE
Simplify file detection logic and allow remote index files

### DIFF
--- a/doc/release.rst
+++ b/doc/release.rst
@@ -7,6 +7,17 @@ Release 0.12.0
 
 * [#473] A new FastxRecord class that can be instantiated from class and
   modified in-place. Replaces PersistentFastqProxy.
+* [#521] In AligmentFile, Simplify file detection logic and allow remote index files
+  * Removed attempts to guess data and index file names; this is magic left
+    to htslib.
+  * Removed file existence check prior to opening files with htslib
+  * Better error checking after opening files that raise the appropriate
+    error (IOError for when errno is set, ValueError otherwise for backward
+    compatibility).
+  * Report IO errors when loading an index by name.
+  * Allow remote indices (tested using S3 signed URLs).
+  * Document filepath_index and make it an alias for index_filename.
+  * Added a require_index parameter to AlignmentFile
 
 
 Release 0.11.2.2

--- a/pysam/libcbcf.pyx
+++ b/pysam/libcbcf.pyx
@@ -4187,16 +4187,16 @@ cdef class VariantFile(HTSFile):
 
         elif mode.startswith(b'r'):
             # open file for reading
-            if not self._exists():
-                raise IOError('file `{}` not found'.format(filename))
-
             self.htsfile = self._open_htsfile()
 
             if not self.htsfile:
-                raise ValueError("could not open file `{}` (mode='{}') - is it VCF/BCF format?".format(filename, mode))
+                if errno:
+                    raise IOError(errno, 'could not open variant file `{}`: {}'.format(filename, force_str(strerror(errno))))
+                else:
+                    raise ValueError('could not open variant file `{}`'.format(filename))
 
             if self.htsfile.format.format not in (bcf, vcf):
-                raise ValueError("invalid file `{}` (mode='{}') - is it VCF/BCF format?".format(filename, mode))
+                raise ValueError('invalid file `{}` (mode=`{}`) - is it VCF/BCF format?'.format(filename, mode))
 
             self.check_truncation(ignore_truncation)
 
@@ -4206,7 +4206,7 @@ cdef class VariantFile(HTSFile):
             try:
                 self.header = makeVariantHeader(hdr)
             except ValueError:
-                raise ValueError("file `{}` does not have valid header (mode='{}') - is it VCF/BCF format?".format(filename, mode))
+                raise ValueError('file `{}` does not have valid header (mode=`{}`) - is it VCF/BCF format?'.format(filename, mode))
 
             if isinstance(self.filename, bytes):
                 cfilename = self.filename
@@ -4231,7 +4231,7 @@ cdef class VariantFile(HTSFile):
             if not self.is_stream:
                 self.start_offset = self.tell()
         else:
-            raise ValueError("unknown mode {}".format(mode))
+            raise ValueError('unknown mode {}'.format(mode))
 
     def reset(self):
         """reset file position to beginning of file just after the header."""

--- a/pysam/libchtslib.pyx
+++ b/pysam/libchtslib.pyx
@@ -562,14 +562,6 @@ cdef class HTSFile(object):
             with nogil:
                 return hts_hopen(hfile, cfilename, cmode)
 
-    def _exists(self):
-        """return False iff file is local, a file and exists.
-        """
-        return (not isinstance(self.filename, (str, bytes)) or
-                self.filename == b'-' or
-                self.is_remote or
-                os.path.exists(self.filename))
-
     def parse_region(self, contig=None, start=None, stop=None, region=None,tid=None,
                            reference=None, end=None):
         """parse alternative ways to specify a genomic region. A region can


### PR DESCRIPTION
## Scope

Substantially simplify index loading logic in `AlignmentFile._open`:

* Remove attempts to guess data and index file names; this is magic that I recommend we leave to htslib.
* Remove file existence check prior to opening files with htslib; do check for errors more carefully afterward and raise the appropriate error (`IOError` for when `errno` is set, `ValueError` otherwise for backward compatibility)
* Catch IO errors when explicitly loading an index.
* Allow remote indices (tested using S3 signed URLs, not easily added to the test suite).
* Document `filepath_index` and make it an alias for `index_filename`.
* Added a `require_index` parameter to `AlignmentFile`
