### PR TITLE
Handle unset ref when creating new records

### DIFF
--- a/pysam/libcbcf.pyx
+++ b/pysam/libcbcf.pyx
@@ -1159,7 +1159,13 @@ cdef inline bcf_sync_end(VariantRecord record):
     cdef bcf_hdr_t *hdr = record.header.ptr
     cdef bcf_info_t *info
     cdef int end_id = bcf_header_get_info_id(record.header.ptr, b'END')
-    cdef int ref_len = len(record.ref)
+    cdef int ref_len 
+
+    # allow missing ref when instantiating a new record
+    if record.ref is not None:
+        ref_len = len(record.ref)
+    else:
+        ref_len = 0
 
     # Delete INFO/END if no alleles are present or if rlen is equal to len(ref)
     if not record.ptr.n_allele or record.ptr.rlen == ref_len:


### PR DESCRIPTION
Hi,

I found a small bug in the updated `VariantHeader.new_record` method. When setting the record's initial attributes, the setters' calls to `bcf_sync_end` raise an exception because `record.ref` is `None`. 

I added a quick check in `bcf_sync_end` to handle this case. I think setting `ref_len` to 0 prior to the INFO/END deletion shouldn't have any side effects, since a new record shouldn't have any alleles or a set END anyways. 

This bug could also be solved by setting `ref` before setting the remaining attributes in `new_record`, but I wasn't sure what the desired default would be for `ref` (or if it would be a good idea to force a default). 