### PR TITLE
Allow for building out of tree

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -359,6 +359,8 @@ else:
 
 define_macros = []
 
+samtools_include_dirs = [os.path.abspath("samtools")]
+
 chtslib = Extension(
     "pysam.libchtslib",
     [source_pattern % "htslib",
@@ -385,7 +387,7 @@ csamfile = Extension(
     htslib_sources +
     os_c_files,
     library_dirs=htslib_library_dirs,
-    include_dirs=["pysam", "samtools", "."] + include_os + htslib_include_dirs,
+    include_dirs=["pysam", "."] + samtools_include_dirs + include_os + htslib_include_dirs,
     libraries=external_htslib_libraries + internal_htslib_libraries,
     language="c",
     extra_compile_args=extra_compile_args,
@@ -404,7 +406,7 @@ calignmentfile = Extension(
     htslib_sources +
     os_c_files,
     library_dirs=htslib_library_dirs,
-    include_dirs=["pysam", "samtools"] + include_os + htslib_include_dirs,
+    include_dirs=["pysam"] + samtools_include_dirs + include_os + htslib_include_dirs,
     libraries=external_htslib_libraries + internal_htslib_libraries,
     language="c",
     extra_compile_args=extra_compile_args,
@@ -423,7 +425,7 @@ calignedsegment = Extension(
     htslib_sources +
     os_c_files,
     library_dirs=htslib_library_dirs,
-    include_dirs=["pysam", "samtools", "."] + include_os + htslib_include_dirs,
+    include_dirs=["pysam", "."] + samtools_include_dirs + include_os + htslib_include_dirs,
     libraries=external_htslib_libraries + internal_htslib_libraries,
     language="c",
     extra_compile_args=extra_compile_args,
@@ -467,7 +469,7 @@ csamtools = Extension(
     htslib_sources +
     os_c_files,
     library_dirs=["pysam"] + htslib_library_dirs,
-    include_dirs=["samtools", "pysam", "."] +
+    include_dirs=["pysam", "."] + samtools_include_dirs +
     include_os + htslib_include_dirs,
     libraries=external_htslib_libraries + internal_htslib_libraries,
     language="c",
@@ -482,7 +484,7 @@ cbcftools = Extension(
     htslib_sources +
     os_c_files,
     library_dirs=["pysam"] + htslib_library_dirs,
-    include_dirs=["bcftools", "pysam", "."] +
+    include_dirs=["bcftools", "pysam", "."] + samtools_include_dirs +
     include_os + htslib_include_dirs,
     libraries=external_htslib_libraries + internal_htslib_libraries,
     language="c",


### PR DESCRIPTION
* Gentoo builds all python packages out of tree,
  as is best practice. Using `-Isamtools` implicitly
  assumes that everything is being built inplace.

  See also: https://bugs.gentoo.org/show_bug.cgi?id=629670