### PR TITLE
Create bcftools/config.h if it doesn't exist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,6 +10,7 @@ include KNOWN_BUGS
 include THANKS
 include cy_build.py
 include requirements.txt
+exclude bcftools/config.h
 include pysam/libc*.pxd
 include pysam/libc*.pyx
 include pysam/libc*.c

--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,8 @@ package_list = ['pysam',
 package_dirs = {'pysam': 'pysam',
                 'pysam.include.samtools': 'samtools',
                 'pysam.include.bcftools': 'bcftools'}
-config_headers = ["samtools/config.h"]
+config_headers = ["samtools/config.h",
+                  "bcftools/config.h"]
 
 from cy_build import CyExtension as Extension, cy_build_ext as build_ext
 


### PR DESCRIPTION
since bcftools and samtools 1.5 are using the same build system,
they need to be treated the same way. Compilation fails when bcftools
can't find its config.h.