### PR TITLE
Assert on reads with invalid MD tags

### DIFF
--- a/pysam/libcalignedsegment.pyx
+++ b/pysam/libcalignedsegment.pyx
@@ -578,6 +578,32 @@ cdef inline uint32_t get_alignment_length(bam1_t * src):
         l += cigar_p[k] >> BAM_CIGAR_SHIFT
     return l
 
+cdef inline uint32_t get_md_reference_length(char * md_tag):
+    cdef int l = 0
+    cdef int md_idx = 0
+    cdef int nmatches = 0
+
+    while md_tag[md_idx] != 0:
+        if md_tag[md_idx] >= 48 and md_tag[md_idx] <= 57:
+            nmatches *= 10
+            nmatches += md_tag[md_idx] - 48
+            md_idx += 1
+            continue
+        else:
+            l += nmatches
+            nmatches = 0
+            if md_tag[md_idx] == '^':
+                md_idx += 1
+                while md_tag[md_idx] >= 65 and md_tag[md_idx] <= 90:
+                    md_idx += 1
+                    l += 1
+            else:
+                # save mismatch and change to lower case
+                md_idx += 1
+                l += 1
+
+    l += nmatches
+    return l
 
 # TODO: avoid string copying for getSequenceInRange, reconstituneSequenceFromMD, ...
 cdef inline bytes build_alignment_sequence(bam1_t * src):
@@ -666,6 +692,10 @@ cdef inline bytes build_alignment_sequence(bam1_t * src):
     cdef char * md_tag = <char*>bam_aux2Z(md_tag_ptr)
     cdef int md_idx = 0
     s_idx = 0
+
+    cdef uint32_t md_len = get_md_reference_length(md_tag)
+    if md_len > max_len:
+        raise AssertionError("Invalid MD tag: MD length {} mismatch with CIGAR length {}".format(md_len, max_len))
 
     while md_tag[md_idx] != 0:
         # c is numerical

--- a/pysam/libcalignedsegment.pyx
+++ b/pysam/libcalignedsegment.pyx
@@ -598,7 +598,6 @@ cdef inline uint32_t get_md_reference_length(char * md_tag):
                     md_idx += 1
                     l += 1
             else:
-                # save mismatch and change to lower case
                 md_idx += 1
                 l += 1
 
@@ -693,8 +692,19 @@ cdef inline bytes build_alignment_sequence(bam1_t * src):
     cdef int md_idx = 0
     s_idx = 0
 
+    # Check if MD tag is valid by matching CIGAR length to MD tag defined length
+    # Insertions would be in addition to what is described by MD, so we calculate
+    # the number of insertions seperately.
+    insertions = 0
+
+    while s[s_idx] != 0:
+        if s[s_idx] >= 'a':
+            insertions += 1
+        s_idx += 1
+    s_idx = 0
+
     cdef uint32_t md_len = get_md_reference_length(md_tag)
-    if md_len > max_len:
+    if md_len + insertions > max_len:
         raise AssertionError("Invalid MD tag: MD length {} mismatch with CIGAR length {}".format(md_len, max_len))
 
     while md_tag[md_idx] != 0:


### PR DESCRIPTION
Its possible that MD tag derived seqeunce length is longer than CIGAR
alignment length. In such cases, building alignment sequence can lead
to a buffer overflow error. Such reads will now generate an assertion.