### PR TITLE
Improve assert log for mismatched MD tag reads

### DIFF
--- a/pysam/libcalignedsegment.pyx
+++ b/pysam/libcalignedsegment.pyx
@@ -705,7 +705,9 @@ cdef inline bytes build_alignment_sequence(bam1_t * src):
 
     cdef uint32_t md_len = get_md_reference_length(md_tag)
     if md_len + insertions > max_len:
-        raise AssertionError("Invalid MD tag: MD length {} mismatch with CIGAR length {}".format(md_len, max_len))
+        raise AssertionError(
+            "Invalid MD tag: MD length {} mismatch with CIGAR length {} and {} insertions".format(
+            md_len, max_len, insertions))
 
     while md_tag[md_idx] != 0:
         # c is numerical


### PR DESCRIPTION
Include insertion length along with the MD and CIGAR details in assert error