### PR TITLE
Provide default alternate allele when constructing a new VariantRecord

### DIFF
--- a/pysam/libcbcf.pyx
+++ b/pysam/libcbcf.pyx
@@ -1185,13 +1185,15 @@ cdef inline bcf_sync_end(VariantRecord record):
         bcf_info_set_value(record, b'END', record.ptr.pos + record.ptr.rlen)
 
 
-cdef inline bint has_symbolic_allele(VariantRecord record):
-    # Check if alternate allele is symbolic
-    if record.ptr.n_allele >= 2:
-        alt = record.ptr.d.allele[1]
-        return (alt[0] == b'<' and alt[len(alt) - 1] == b'>')
-    else:
-        return False
+cdef inline int has_symbolic_allele(VariantRecord record):
+    """Return index of first symbolic allele. 0 if no symbolic alleles."""
+
+    for i in range(1, record.ptr.n_allele):
+        alt = record.ptr.d.allele[i]
+        if alt[0] == b'<' and alt[len(alt) - 1] == b'>':
+            return i
+
+    return 0
 
 
 ########################################################################

--- a/pysam/libcbcf.pyx
+++ b/pysam/libcbcf.pyx
@@ -3143,7 +3143,7 @@ cdef class VariantRecord(object):
             alleles = [r.d.allele[i] for i in range(r.n_allele)]
             alleles[0] = value
         else:
-            alleles = [value]
+            alleles = [value, '<NON_REF>']
         self.alleles = alleles
         self.ptr.rlen = len(value)
         bcf_sync_end(self)


### PR DESCRIPTION
Hi,

I found a bug where it wasn't possible to set the `ref` of a newly constructed VariantRecord. In the absence of any defined alleles, the ref setter method sets the record's alleles to be the list of only the reference allele. However, the alleles setter method requires at least two alleles to be passed. I fixed this by providing a generic "NON_REF" allele along with the ref allele if no others are present.