### PR TITLE
Allow loading index without tbi extension

### DIFF
--- a/pysam/libctabix.pyx
+++ b/pysam/libctabix.pyx
@@ -72,7 +72,7 @@ cimport pysam.libctabixproxies as ctabixproxies
 
 from pysam.libchtslib cimport htsFile, hts_open, hts_close, HTS_IDX_START,\
     BGZF, bgzf_open, bgzf_dopen, bgzf_close, bgzf_write, \
-    tbx_index_build2, tbx_index_load, tbx_itr_queryi, tbx_itr_querys, \
+    tbx_index_build2, tbx_index_load2, tbx_itr_queryi, tbx_itr_querys, \
     tbx_conf_t, tbx_seqnames, tbx_itr_next, tbx_itr_destroy, \
     tbx_destroy, hisremote, region_list, hts_getline, \
     TBX_GENERIC, TBX_SAM, TBX_VCF, TBX_UCSC
@@ -385,7 +385,7 @@ cdef class TabixFile:
         #    raise ValueError("file does not contain region data")
 
         with nogil:
-            self.index = tbx_index_load(cfilename_index)
+            self.index = tbx_index_load2(cfilename, cfilename_index)
 
         if self.index == NULL:
             raise IOError("could not open index for `%s`" % filename)
@@ -534,6 +534,7 @@ cdef class TabixFile:
         def __get__(self):
 
             cdef char *cfilename = self.filename
+            cdef char *cfilename_index = self.filename_index
             
             cdef kstring_t buffer
             buffer.l = buffer.m = 0
@@ -550,7 +551,7 @@ cdef class TabixFile:
                 raise OSError("could not open {} for reading header".format(self.filename))
 
             with nogil:
-                tbx = tbx_index_load(cfilename)
+                tbx = tbx_index_load2(cfilename, cfilename_index)
                 
             if tbx == NULL:
                 raise OSError("could not load .tbi/.csi index of {}".format(self.filename))

--- a/pysam/libctabix.pyx
+++ b/pysam/libctabix.pyx
@@ -374,6 +374,7 @@ cdef class TabixFile:
 
         # open file
         cdef char *cfilename = self.filename
+        cdef char *cfilename_index = self.filename_index
         with nogil:
             self.htsfile = hts_open(cfilename, 'r')
 
@@ -383,9 +384,8 @@ cdef class TabixFile:
         #if self.htsfile.format.category != region_list:
         #    raise ValueError("file does not contain region data")
 
-        cfilename = self.filename_index
         with nogil:
-            self.index = tbx_index_load(cfilename)
+            self.index = tbx_index_load(cfilename_index)
 
         if self.index == NULL:
             raise IOError("could not open index for `%s`" % filename)

--- a/tests/tabix_test.py
+++ b/tests/tabix_test.py
@@ -1100,6 +1100,7 @@ class TestIndexArgument(unittest.TestCase):
     filename_dst = "tmp_example.vcf.gz"
     index_src = os.path.join(TABIX_DATADIR, "example.vcf.gz.tbi")
     index_dst = "tmp_index_example.vcf.gz.tbi"
+    index_dst_dat = "tmp_index_example.vcf.gz.tbi.dat"
     preset = "vcf"
 
     def testFetchAll(self):
@@ -1120,6 +1121,25 @@ class TestIndexArgument(unittest.TestCase):
 
         os.unlink(self.filename_dst)
         os.unlink(self.index_dst)
+
+    def testLoadIndexWithoutTbiExtension(self):
+        shutil.copyfile(self.filename_src, self.filename_dst)
+        shutil.copyfile(self.index_src, self.index_dst_dat)
+
+        with pysam.TabixFile(
+                self.filename_src, "r", index=self.index_src) as same_basename_file:
+            same_basename_results = list(same_basename_file.fetch())
+
+        with pysam.TabixFile(
+            self.filename_dst, "r", index=self.index_dst_dat) as diff_index_file:
+            diff_index_result = list(diff_index_file.fetch())
+
+        self.assertEqual(len(same_basename_results), len(diff_index_result))
+        for x, y in zip(same_basename_results, diff_index_result):
+            self.assertEqual(x, y)
+
+        os.unlink(self.filename_dst)
+        os.unlink(self.index_dst_dat)
 
 
 def _TestMultipleIteratorsHelper(filename, multiple_iterators):


### PR DESCRIPTION
This seems to be necessary to create TabixFile instances with indexes that don't end in `.tbi`.