### PR TITLE
{AH} permit Number=G in INFO records

### DIFF
--- a/pysam/libcbcf.pyx
+++ b/pysam/libcbcf.pyx
@@ -222,8 +222,8 @@ cdef inline int is_gt_fmt(bcf_hdr_t *hdr, int fmt_id):
 
 
 cdef inline int bcf_genotype_count(bcf_hdr_t *hdr, bcf1_t *rec, int sample) except -1:
-    if sample < 0:
-        raise ValueError('genotype is only valid as a format field')
+    # if sample < 0:
+    #     raise ValueError('genotype is only valid as a format field')
 
     cdef int32_t *gt_arr = NULL
     cdef int ngt = 0

--- a/pysam/libcbcf.pyx
+++ b/pysam/libcbcf.pyx
@@ -223,6 +223,9 @@ cdef inline int is_gt_fmt(bcf_hdr_t *hdr, int fmt_id):
 
 cdef inline int bcf_genotype_count(bcf_hdr_t *hdr, bcf1_t *rec, int sample) except -1:
 
+    if sample < 0:
+        raise ValueError('genotype is only valid as a format field')
+
     cdef int32_t *gt_arr = NULL
     cdef int ngt = 0
     ngt = bcf_get_genotypes(hdr, rec, &gt_arr, &ngt)

--- a/pysam/libcbcf.pyx
+++ b/pysam/libcbcf.pyx
@@ -222,8 +222,6 @@ cdef inline int is_gt_fmt(bcf_hdr_t *hdr, int fmt_id):
 
 
 cdef inline int bcf_genotype_count(bcf_hdr_t *hdr, bcf1_t *rec, int sample) except -1:
-    # if sample < 0:
-    #     raise ValueError('genotype is only valid as a format field')
 
     cdef int32_t *gt_arr = NULL
     cdef int ngt = 0

--- a/tests/VariantFile_test.py
+++ b/tests/VariantFile_test.py
@@ -70,21 +70,30 @@ class TestMissingSamples(unittest.TestCase):
             encode=False)
 
     def check(self, filename):
-        """see issue XYZ"""
+        """see issue #593"""
         fn = os.path.join(CBCF_DATADIR, filename)
         self.assertEqual(True, os.path.exists(fn))
+        expect_fail = not "fixed" in self.filename
         with pysam.VariantFile(fn) as inf:
             rec = next(inf.fetch())
-            print(rec.info.keys())
-            print(rec.info["AC"])
-            print(rec.info["GC"])
+            if expect_fail:
+                self.assertRaises(ValueError, rec.info.__getitem__, "GC")
+            else:
+                self.assertEqual(rec.info["GC"], (27, 35, 16))
 
     def testVCF(self):
         self.check(self.filename)
 
     def testVCFGZ(self):
         self.check(self.filename + ".gz")
-        
+
+
+class TestMissingSamplesFixed(TestMissingSamples):
+    # workaround for NUMBER=G in INFO records:
+    # perl 's/Number=G/Number=./ if (/INFO/)'
+    
+    filename = "gnomad_fixed.vcf"
+
 
 class TestOpening(unittest.TestCase):
 

--- a/tests/VariantFile_test.py
+++ b/tests/VariantFile_test.py
@@ -60,6 +60,32 @@ class TestMissingGenotypes(unittest.TestCase):
         self.check(self.filename + ".gz")
 
 
+class TestMissingSamples(unittest.TestCase):
+
+    filename = "gnomad.vcf"
+
+    def setUp(self):
+        self.compare = load_and_convert(
+            os.path.join(CBCF_DATADIR, self.filename),
+            encode=False)
+
+    def check(self, filename):
+        """see issue XYZ"""
+        fn = os.path.join(CBCF_DATADIR, filename)
+        self.assertEqual(True, os.path.exists(fn))
+        with pysam.VariantFile(fn) as inf:
+            rec = next(inf.fetch())
+            print(rec.info.keys())
+            print(rec.info["AC"])
+            print(rec.info["GC"])
+
+    def testVCF(self):
+        self.check(self.filename)
+
+    def testVCFGZ(self):
+        self.check(self.filename + ".gz")
+        
+
 class TestOpening(unittest.TestCase):
 
     def testMissingFile(self):

--- a/tests/cbcf_data/gnomad.vcf
+++ b/tests/cbcf_data/gnomad.vcf
@@ -1,0 +1,200 @@
+##fileformat=VCFv4.2
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=AD,Number=R,Type=Integer,Description="Allelic depths for the ref and alt alleles in the order listed">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read Depth">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=PL,Number=G,Type=Integer,Description="Normalized, Phred-scaled likelihoods for genotypes as defined in the VCF specification">
+##FILTER=<ID=RF,Description="Failed random forests filters (SNV cutoff 0.4, indels cutoff 0.4)">
+##FILTER=<ID=AC0,Description="Allele Count is zero (i.e. no high-confidence genotype (GQ >= 20, DP >= 10, AB => 0.2 for het calls))">
+##FILTER=<ID=InbreedingCoeff,Description="InbreedingCoeff < -0.3">
+##FILTER=<ID=LCR,Description="In a low complexity region">
+##FILTER=<ID=SEGDUP,Description="In a segmental duplication region">
+##FILTER=<ID=PASS,Description="All filters passed for at least one of the alleles at that site (see AS_FilterStatus for allele-specific filter status)">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency among genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##INFO=<ID=BaseQRankSum,Number=1,Type=Float,Description="Z-score from Wilcoxon rank sum test of Alt Vs. Ref base qualities">
+##INFO=<ID=ClippingRankSum,Number=1,Type=Float,Description="Z-score from Wilcoxon rank sum test of Alt vs. Ref number of hard clipped bases">
+##INFO=<ID=DB,Number=0,Type=Flag,Description="dbSNP Membership">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth; some reads may have been filtered">
+##INFO=<ID=FS,Number=1,Type=Float,Description="Phred-scaled p-value using Fisher's exact test to detect strand bias">
+##INFO=<ID=InbreedingCoeff,Number=1,Type=Float,Description="Inbreeding coefficient as estimated from the genotype likelihoods per-sample when compared against the Hardy-Weinberg expectation">
+##INFO=<ID=MQ,Number=1,Type=Float,Description="RMS Mapping Quality">
+##INFO=<ID=MQRankSum,Number=1,Type=Float,Description="Z-score from Wilcoxon rank sum test of Alt vs. Ref read mapping qualities">
+##INFO=<ID=QD,Number=1,Type=Float,Description="Variant Confidence/Quality by Depth">
+##INFO=<ID=ReadPosRankSum,Number=1,Type=Float,Description="Z-score from Wilcoxon rank sum test of Alt vs. Ref read position bias">
+##INFO=<ID=SOR,Number=1,Type=Float,Description="Symmetric Odds Ratio of 2x2 contingency table to detect strand bias">
+##INFO=<ID=VQSLOD,Number=1,Type=Float,Description="Log odds ratio of being a true variant versus being false under the trained VQSR gaussian mixture model (deprecated; see AS_RF)">
+##INFO=<ID=VQSR_culprit,Number=1,Type=String,Description="The annotation which was the worst performing in the VQSR Gaussian mixture model (deprecated; see AS_RF)">
+##INFO=<ID=VQSR_NEGATIVE_TRAIN_SITE,Number=0,Type=Flag,Description="This variant was used to build the negative training set of bad variants for VQSR (deprecated; see AS_RF_NEGATIVE_TRAIN)">
+##INFO=<ID=VQSR_POSITIVE_TRAIN_SITE,Number=0,Type=Flag,Description="This variant was used to build the positive training set of good variants for VQSR (deprecated; see AS_RF_POSITIVE_TRAIN)">
+##INFO=<ID=GQ_HIST_ALT,Number=A,Type=String,Description="Histogram for GQ for each allele; Midpoints of histogram bins: 2.5|7.5|12.5|17.5|22.5|27.5|32.5|37.5|42.5|47.5|52.5|57.5|62.5|67.5|72.5|77.5|82.5|87.5|92.5|97.5">
+##INFO=<ID=DP_HIST_ALT,Number=A,Type=String,Description="Histogram for DP for each allele; Midpoints of histogram bins: 2.5|7.5|12.5|17.5|22.5|27.5|32.5|37.5|42.5|47.5|52.5|57.5|62.5|67.5|72.5|77.5|82.5|87.5|92.5|97.5">
+##INFO=<ID=AB_HIST_ALT,Number=A,Type=String,Description="Histogram for Allele Balance in heterozygous individuals for each allele; 100*AD[i_alt]/sum(AD); Midpoints of histogram bins: 2.5|7.5|12.5|17.5|22.5|27.5|32.5|37.5|42.5|47.5|52.5|57.5|62.5|67.5|72.5|77.5|82.5|87.5|92.5|97.5">
+##INFO=<ID=GQ_HIST_ALL,Number=1,Type=String,Description="Histogram for GQ; Midpoints of histogram bins: 2.5|7.5|12.5|17.5|22.5|27.5|32.5|37.5|42.5|47.5|52.5|57.5|62.5|67.5|72.5|77.5|82.5|87.5|92.5|97.5">
+##INFO=<ID=DP_HIST_ALL,Number=1,Type=String,Description="Histogram for DP; Midpoints of histogram bins: 2.5|7.5|12.5|17.5|22.5|27.5|32.5|37.5|42.5|47.5|52.5|57.5|62.5|67.5|72.5|77.5|82.5|87.5|92.5|97.5">
+##INFO=<ID=AB_HIST_ALL,Number=1,Type=String,Description="Histogram for Allele Balance in heterozygous individuals; 100*AD[i_alt]/sum(AD); Midpoints of histogram bins: 2.5|7.5|12.5|17.5|22.5|27.5|32.5|37.5|42.5|47.5|52.5|57.5|62.5|67.5|72.5|77.5|82.5|87.5|92.5|97.5">
+##INFO=<ID=AC_AFR,Number=A,Type=Integer,Description="Allele count in African/African American genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AC_AMR,Number=A,Type=Integer,Description="Allele count in Admixed American genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AC_ASJ,Number=A,Type=Integer,Description="Allele count in Ashkenazi Jewish genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AC_EAS,Number=A,Type=Integer,Description="Allele count in East Asian genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AC_FIN,Number=A,Type=Integer,Description="Allele count in Finnish genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AC_NFE,Number=A,Type=Integer,Description="Allele count in Non-Finnish European genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AC_OTH,Number=A,Type=Integer,Description="Allele count in Other (population not assigned) genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AC_Male,Number=A,Type=Integer,Description="Allele count in Male genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AC_Female,Number=A,Type=Integer,Description="Allele count in Female genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AN_AFR,Number=1,Type=Integer,Description="Total number of alleles in African/African American called genotypes">
+##INFO=<ID=AN_AMR,Number=1,Type=Integer,Description="Total number of alleles in Admixed American called genotypes">
+##INFO=<ID=AN_ASJ,Number=1,Type=Integer,Description="Total number of alleles in Ashkenazi Jewish called genotypes">
+##INFO=<ID=AN_EAS,Number=1,Type=Integer,Description="Total number of alleles in East Asian called genotypes">
+##INFO=<ID=AN_FIN,Number=1,Type=Integer,Description="Total number of alleles in Finnish called genotypes">
+##INFO=<ID=AN_NFE,Number=1,Type=Integer,Description="Total number of alleles in Non-Finnish European called genotypes">
+##INFO=<ID=AN_OTH,Number=1,Type=Integer,Description="Total number of alleles in Other (population not assigned) called genotypes">
+##INFO=<ID=AN_Male,Number=1,Type=Integer,Description="Total number of alleles in Male called genotypes">
+##INFO=<ID=AN_Female,Number=1,Type=Integer,Description="Total number of alleles in Female called genotypes">
+##INFO=<ID=AF_AFR,Number=A,Type=Float,Description="Allele Frequency among African/African American genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF_AMR,Number=A,Type=Float,Description="Allele Frequency among Admixed American genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF_ASJ,Number=A,Type=Float,Description="Allele Frequency among Ashkenazi Jewish genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF_EAS,Number=A,Type=Float,Description="Allele Frequency among East Asian genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF_FIN,Number=A,Type=Float,Description="Allele Frequency among Finnish genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF_NFE,Number=A,Type=Float,Description="Allele Frequency among Non-Finnish European genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF_OTH,Number=A,Type=Float,Description="Allele Frequency among Other (population not assigned) genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF_Male,Number=A,Type=Float,Description="Allele Frequency among Male genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF_Female,Number=A,Type=Float,Description="Allele Frequency among Female genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=GC_AFR,Number=G,Type=Integer,Description="Count of African/African American individuals for each genotype">
+##INFO=<ID=GC_AMR,Number=G,Type=Integer,Description="Count of Admixed American individuals for each genotype">
+##INFO=<ID=GC_ASJ,Number=G,Type=Integer,Description="Count of Ashkenazi Jewish individuals for each genotype">
+##INFO=<ID=GC_EAS,Number=G,Type=Integer,Description="Count of East Asian individuals for each genotype">
+##INFO=<ID=GC_FIN,Number=G,Type=Integer,Description="Count of Finnish individuals for each genotype">
+##INFO=<ID=GC_NFE,Number=G,Type=Integer,Description="Count of Non-Finnish European individuals for each genotype">
+##INFO=<ID=GC_OTH,Number=G,Type=Integer,Description="Count of Other (population not assigned) individuals for each genotype">
+##INFO=<ID=GC_Male,Number=G,Type=Integer,Description="Count of Male individuals for each genotype">
+##INFO=<ID=GC_Female,Number=G,Type=Integer,Description="Count of Female individuals for each genotype">
+##INFO=<ID=AC_raw,Number=A,Type=Integer,Description="Allele counts before filtering low-confidence genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AN_raw,Number=1,Type=Integer,Description="Total number of alleles before filtering low-confidence genotypes">
+##INFO=<ID=AF_raw,Number=A,Type=Float,Description="Allele frequency before filtering low-confidence genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=GC_raw,Number=G,Type=Integer,Description="Raw count of individuals for each genotype before filtering low-confidence genotypes">
+##INFO=<ID=GC,Number=G,Type=Integer,Description="Count of individuals for each genotype">
+##INFO=<ID=Hom_AFR,Number=A,Type=Integer,Description="Count of homozygous African/African American individuals">
+##INFO=<ID=Hom_AMR,Number=A,Type=Integer,Description="Count of homozygous Admixed American individuals">
+##INFO=<ID=Hom_ASJ,Number=A,Type=Integer,Description="Count of homozygous Ashkenazi Jewish individuals">
+##INFO=<ID=Hom_EAS,Number=A,Type=Integer,Description="Count of homozygous East Asian individuals">
+##INFO=<ID=Hom_FIN,Number=A,Type=Integer,Description="Count of homozygous Finnish individuals">
+##INFO=<ID=Hom_NFE,Number=A,Type=Integer,Description="Count of homozygous Non-Finnish European individuals">
+##INFO=<ID=Hom_OTH,Number=A,Type=Integer,Description="Count of homozygous Other (population not assigned) individuals">
+##INFO=<ID=Hom_Male,Number=A,Type=Integer,Description="Count of homozygous Male individuals">
+##INFO=<ID=Hom_Female,Number=A,Type=Integer,Description="Count of homozygous Female individuals">
+##INFO=<ID=Hom_raw,Number=A,Type=Integer,Description="Count of homozygous individuals in raw genotypes before filtering low-confidence genotypes">
+##INFO=<ID=Hom,Number=A,Type=Integer,Description="Count of homozygous individuals">
+##INFO=<ID=STAR_AC,Number=1,Type=Integer,Description="AC of deletions spanning this position">
+##INFO=<ID=STAR_AC_raw,Number=1,Type=Integer,Description="Allele counts of deletions spanning this position before filtering low-confidence genotypes">
+##INFO=<ID=STAR_Hom,Number=1,Type=Integer,Description="Count of individuals homozygous for a deletion spanning this position">
+##INFO=<ID=POPMAX,Number=A,Type=String,Description="Population with max AF">
+##INFO=<ID=AC_POPMAX,Number=A,Type=Integer,Description="AC in the population with the max AF">
+##INFO=<ID=AN_POPMAX,Number=A,Type=Integer,Description="AN in the population with the max AF">
+##INFO=<ID=AF_POPMAX,Number=A,Type=Float,Description="Maximum Allele Frequency across populations (excluding OTH)">
+##INFO=<ID=DP_MEDIAN,Number=A,Type=Integer,Description="Median DP in carriers of each allele">
+##INFO=<ID=DREF_MEDIAN,Number=A,Type=Float,Description="Median dosage of homozygous reference in carriers of each allele">
+##INFO=<ID=GQ_MEDIAN,Number=A,Type=Integer,Description="Median GQ in carriers of each allele">
+##INFO=<ID=AB_MEDIAN,Number=A,Type=Float,Description="Median allele balance in heterozygote carriers of each allele">
+##INFO=<ID=AS_RF,Number=A,Type=Float,Description="Random Forests probability for each allele">
+##INFO=<ID=AS_FilterStatus,Number=A,Type=String,Description="Random Forests filter status for each allele">
+##INFO=<ID=AS_RF_POSITIVE_TRAIN,Number=.,Type=Integer,Description="Contains the indices of all alleles used as positive examples during training of random forests">
+##INFO=<ID=AS_RF_NEGATIVE_TRAIN,Number=.,Type=Integer,Description="Contains the indices of all alleles used as negative examples during training of random forests">
+##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|ALLELE_NUM|DISTANCE|STRAND|FLAGS|VARIANT_CLASS|MINIMISED|SYMBOL_SOURCE|HGNC_ID|CANONICAL|TSL|APPRIS|CCDS|ENSP|SWISSPROT|TREMBL|UNIPARC|GENE_PHENO|SIFT|PolyPhen|DOMAINS|HGVS_OFFSET|GMAF|AFR_MAF|AMR_MAF|EAS_MAF|EUR_MAF|SAS_MAF|AA_MAF|EA_MAF|ExAC_MAF|ExAC_Adj_MAF|ExAC_AFR_MAF|ExAC_AMR_MAF|ExAC_EAS_MAF|ExAC_FIN_MAF|ExAC_NFE_MAF|ExAC_OTH_MAF|ExAC_SAS_MAF|CLIN_SIG|SOMATIC|PHENO|PUBMED|MOTIF_NAME|MOTIF_POS|HIGH_INF_POS|MOTIF_SCORE_CHANGE|LoF|LoF_filter|LoF_flags|LoF_info">
+##contig=<ID=1,length=249250621>
+##contig=<ID=2,length=243199373>
+##contig=<ID=3,length=198022430>
+##contig=<ID=4,length=191154276>
+##contig=<ID=5,length=180915260>
+##contig=<ID=6,length=171115067>
+##contig=<ID=7,length=159138663>
+##contig=<ID=8,length=146364022>
+##contig=<ID=9,length=141213431>
+##contig=<ID=10,length=135534747>
+##contig=<ID=11,length=135006516>
+##contig=<ID=12,length=133851895>
+##contig=<ID=13,length=115169878>
+##contig=<ID=14,length=107349540>
+##contig=<ID=15,length=102531392>
+##contig=<ID=16,length=90354753>
+##contig=<ID=17,length=81195210>
+##contig=<ID=18,length=78077248>
+##contig=<ID=19,length=59128983>
+##contig=<ID=20,length=63025520>
+##contig=<ID=21,length=48129895>
+##contig=<ID=22,length=51304566>
+##contig=<ID=X,length=155270560>
+##contig=<ID=Y,length=59373566>
+##contig=<ID=MT,length=16569>
+##contig=<ID=GL000207.1,length=4262>
+##contig=<ID=GL000226.1,length=15008>
+##contig=<ID=GL000229.1,length=19913>
+##contig=<ID=GL000231.1,length=27386>
+##contig=<ID=GL000210.1,length=27682>
+##contig=<ID=GL000239.1,length=33824>
+##contig=<ID=GL000235.1,length=34474>
+##contig=<ID=GL000201.1,length=36148>
+##contig=<ID=GL000247.1,length=36422>
+##contig=<ID=GL000245.1,length=36651>
+##contig=<ID=GL000197.1,length=37175>
+##contig=<ID=GL000203.1,length=37498>
+##contig=<ID=GL000246.1,length=38154>
+##contig=<ID=GL000249.1,length=38502>
+##contig=<ID=GL000196.1,length=38914>
+##contig=<ID=GL000248.1,length=39786>
+##contig=<ID=GL000244.1,length=39929>
+##contig=<ID=GL000238.1,length=39939>
+##contig=<ID=GL000202.1,length=40103>
+##contig=<ID=GL000234.1,length=40531>
+##contig=<ID=GL000232.1,length=40652>
+##contig=<ID=GL000206.1,length=41001>
+##contig=<ID=GL000240.1,length=41933>
+##contig=<ID=GL000236.1,length=41934>
+##contig=<ID=GL000241.1,length=42152>
+##contig=<ID=GL000243.1,length=43341>
+##contig=<ID=GL000242.1,length=43523>
+##contig=<ID=GL000230.1,length=43691>
+##contig=<ID=GL000237.1,length=45867>
+##contig=<ID=GL000233.1,length=45941>
+##contig=<ID=GL000204.1,length=81310>
+##contig=<ID=GL000198.1,length=90085>
+##contig=<ID=GL000208.1,length=92689>
+##contig=<ID=GL000191.1,length=106433>
+##contig=<ID=GL000227.1,length=128374>
+##contig=<ID=GL000228.1,length=129120>
+##contig=<ID=GL000214.1,length=137718>
+##contig=<ID=GL000221.1,length=155397>
+##contig=<ID=GL000209.1,length=159169>
+##contig=<ID=GL000218.1,length=161147>
+##contig=<ID=GL000220.1,length=161802>
+##contig=<ID=GL000213.1,length=164239>
+##contig=<ID=GL000211.1,length=166566>
+##contig=<ID=GL000199.1,length=169874>
+##contig=<ID=GL000217.1,length=172149>
+##contig=<ID=GL000216.1,length=172294>
+##contig=<ID=GL000215.1,length=172545>
+##contig=<ID=GL000205.1,length=174588>
+##contig=<ID=GL000219.1,length=179198>
+##contig=<ID=GL000224.1,length=179693>
+##contig=<ID=GL000223.1,length=180455>
+##contig=<ID=GL000195.1,length=182896>
+##contig=<ID=GL000212.1,length=186858>
+##contig=<ID=GL000222.1,length=186861>
+##contig=<ID=GL000200.1,length=187035>
+##contig=<ID=GL000193.1,length=189789>
+##contig=<ID=GL000194.1,length=191469>
+##contig=<ID=GL000225.1,length=211173>
+##contig=<ID=GL000192.1,length=547496>
+##contig=<ID=NC_007605,length=171823>
+##reference=file:///seq/references/Homo_sapiens_assembly19/v1/Homo_sapiens_assembly19.fasta
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+22	16050036	rs374742143	A	C	442156.34	RF	AC=67;AF=4.29487e-01;AN=156;BaseQRankSum=7.36000e-01;ClippingRankSum=2.96000e-01;DB;DP=50165;FS=7.05600e+00;InbreedingCoeff=3.82000e-01;MQ=2.71500e+01;MQRankSum=-1.02600e+00;QD=2.47500e+01;ReadPosRankSum=-2.11000e-01;SOR=1.26750e+01;VQSLOD=-9.58600e+02;VQSR_culprit=MQ;GQ_HIST_ALT=16|1279|299|254|155|24|16|28|50|135|78|4|6|11|32|43|6|4|3|35;DP_HIST_ALT=1769|653|51|5|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALT=0|0|0|2|5|24|36|11|89|2|125|31|61|85|24|60|34|8|3|7;GQ_HIST_ALL=2359|2810|730|651|296|51|34|33|53|135|78|4|6|11|32|43|6|4|3|35;DP_HIST_ALL=5518|1756|94|6|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALL=0|0|0|2|5|24|36|11|89|2|125|31|61|85|24|60|34|8|3|7;AC_AFR=3;AC_AMR=7;AC_ASJ=0;AC_EAS=0;AC_FIN=50;AC_NFE=3;AC_OTH=4;AC_Male=32;AC_Female=35;AN_AFR=14;AN_AMR=10;AN_ASJ=0;AN_EAS=0;AN_FIN=84;AN_NFE=42;AN_OTH=6;AN_Male=80;AN_Female=76;AF_AFR=2.14286e-01;AF_AMR=7.00000e-01;AF_ASJ=.;AF_EAS=.;AF_FIN=5.95238e-01;AF_NFE=7.14286e-02;AF_OTH=6.66667e-01;AF_Male=4.00000e-01;AF_Female=4.60526e-01;GC_AFR=4,3,0;GC_AMR=0,3,2;GC_ASJ=0,0,0;GC_EAS=0,0,0;GC_FIN=4,26,12;GC_NFE=18,3,0;GC_OTH=1,0,2;GC_Male=16,16,8;GC_Female=11,19,8;AC_raw=4349;AN_raw=14748;AF_raw=2.94887e-01;GC_raw=4896,607,1871;GC=27,35,16;Hom_AFR=0;Hom_AMR=2;Hom_ASJ=0;Hom_EAS=0;Hom_FIN=12;Hom_NFE=0;Hom_OTH=2;Hom_Male=8;Hom_Female=8;Hom_raw=1871;Hom=16;POPMAX=AMR;AC_POPMAX=7;AN_POPMAX=10;AF_POPMAX=7.00000e-01;DP_MEDIAN=3;DREF_MEDIAN=5.60406e-10;GQ_MEDIAN=12;AB_MEDIAN=5.55556e-01;AS_RF=4.71609e-02;AS_FilterStatus=RF;CSQ=C|intergenic_variant|MODIFIER|||||||||||||||rs374742143|1||||SNV|1||||||||||||||||||||||||||||||||||||||||||||
+22	16050068	.	A	G	82.46	RF;AC0	AC=0;AF=0.00000e+00;AN=2708;DP=111486;FS=0.00000e+00;InbreedingCoeff=-3.63000e-02;MQ=3.20200e+01;QD=1.64900e+01;SOR=3.61100e+00;VQSLOD=-9.28900e+01;VQSR_culprit=MQ;GQ_HIST_ALT=0|0|0|1|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0;DP_HIST_ALT=0|1|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALT=0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0;GQ_HIST_ALL=1227|4189|2184|3537|2071|618|693|346|97|92|61|9|18|0|7|4|4|0|0|0;DP_HIST_ALL=7502|6289|1163|169|26|8|0|0|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALL=0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0;AC_AFR=0;AC_AMR=0;AC_ASJ=0;AC_EAS=0;AC_FIN=0;AC_NFE=0;AC_OTH=0;AC_Male=0;AC_Female=0;AN_AFR=280;AN_AMR=162;AN_ASJ=34;AN_EAS=74;AN_FIN=748;AN_NFE=1300;AN_OTH=110;AN_Male=1584;AN_Female=1124;AF_AFR=0.00000e+00;AF_AMR=0.00000e+00;AF_ASJ=0.00000e+00;AF_EAS=0.00000e+00;AF_FIN=0.00000e+00;AF_NFE=0.00000e+00;AF_OTH=0.00000e+00;AF_Male=0.00000e+00;AF_Female=0.00000e+00;GC_AFR=140,0,0;GC_AMR=81,0,0;GC_ASJ=17,0,0;GC_EAS=37,0,0;GC_FIN=374,0,0;GC_NFE=650,0,0;GC_OTH=55,0,0;GC_Male=792,0,0;GC_Female=562,0,0;AC_raw=2;AN_raw=30314;AF_raw=6.59761e-05;GC_raw=15156,0,1;GC=1354,0,0;Hom_AFR=0;Hom_AMR=0;Hom_ASJ=0;Hom_EAS=0;Hom_FIN=0;Hom_NFE=0;Hom_OTH=0;Hom_Male=0;Hom_Female=0;Hom_raw=1;Hom=0;POPMAX=.;AC_POPMAX=.;AN_POPMAX=.;AF_POPMAX=.;DP_MEDIAN=5;DREF_MEDIAN=1.22034e-16;GQ_MEDIAN=15;AB_MEDIAN=5.00000e-01;AS_RF=5.87186e-02;AS_FilterStatus=RF|AC0;CSQ=G|intergenic_variant|MODIFIER||||||||||||||||1||||SNV|1||||||||||||||||||||||||||||||||||||||||||||
+22	16050069	.	C	T	43.44	RF;AC0	AC=0;AF=0.00000e+00;AN=2802;BaseQRankSum=7.20000e-01;ClippingRankSum=-1.38000e+00;DP=112972;FS=0.00000e+00;InbreedingCoeff=-3.70000e-02;MQ=3.67700e+01;MQRankSum=7.20000e-01;QD=7.24000e+00;ReadPosRankSum=1.38000e+00;SOR=1.32900e+00;VQSLOD=-3.27400e+01;VQSR_culprit=MQ;GQ_HIST_ALT=0|0|0|0|0|0|0|1|0|0|0|0|0|0|0|0|0|0|0|0;DP_HIST_ALT=0|1|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALT=0|0|0|0|0|0|0|0|0|0|0|0|0|1|0|0|0|0|0|0;GQ_HIST_ALL=1200|4098|2219|3540|2117|622|710|352|104|101|64|10|20|1|8|3|4|0|0|0;DP_HIST_ALL=7405|6348|1203|181|28|8|0|0|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALL=0|0|0|0|0|0|0|0|0|0|0|0|0|1|0|0|0|0|0|0;AC_AFR=0;AC_AMR=0;AC_ASJ=0;AC_EAS=0;AC_FIN=0;AC_NFE=0;AC_OTH=0;AC_Male=0;AC_Female=0;AN_AFR=296;AN_AMR=164;AN_ASJ=36;AN_EAS=70;AN_FIN=766;AN_NFE=1354;AN_OTH=116;AN_Male=1638;AN_Female=1164;AF_AFR=0.00000e+00;AF_AMR=0.00000e+00;AF_ASJ=0.00000e+00;AF_EAS=0.00000e+00;AF_FIN=0.00000e+00;AF_NFE=0.00000e+00;AF_OTH=0.00000e+00;AF_Male=0.00000e+00;AF_Female=0.00000e+00;GC_AFR=148,0,0;GC_AMR=82,0,0;GC_ASJ=18,0,0;GC_EAS=35,0,0;GC_FIN=383,0,0;GC_NFE=677,0,0;GC_OTH=58,0,0;GC_Male=819,0,0;GC_Female=582,0,0;AC_raw=1;AN_raw=30346;AF_raw=3.29533e-05;GC_raw=15172,1,0;GC=1401,0,0;Hom_AFR=0;Hom_AMR=0;Hom_ASJ=0;Hom_EAS=0;Hom_FIN=0;Hom_NFE=0;Hom_OTH=0;Hom_Male=0;Hom_Female=0;Hom_raw=0;Hom=0;POPMAX=.;AC_POPMAX=.;AN_POPMAX=.;AF_POPMAX=.;DP_MEDIAN=6;DREF_MEDIAN=3.16178e-11;GQ_MEDIAN=38;AB_MEDIAN=6.66667e-01;AS_RF=9.22976e-02;AS_FilterStatus=RF|AC0;CSQ=T|intergenic_variant|MODIFIER||||||||||||||||1||||SNV|1||||||||||||||||||||||||||||||||||||||||||||
+22	16050098	.	G	A	242.82	RF	AC=2;AF=2.40964e-04;AN=8300;BaseQRankSum=2.45000e+00;ClippingRankSum=1.03000e-01;DP=167171;FS=0.00000e+00;InbreedingCoeff=-1.46000e-02;MQ=3.06100e+01;MQRankSum=-9.35000e-01;QD=1.05600e+01;ReadPosRankSum=6.60000e-01;SOR=3.84000e-01;VQSLOD=-4.11500e+01;VQSR_culprit=MQ;GQ_HIST_ALT=0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|2;DP_HIST_ALT=0|0|2|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALT=0|0|0|0|0|0|0|0|0|1|1|0|0|0|0|0|0|0|0|0;GQ_HIST_ALL=350|1697|1483|3462|3106|1262|1746|994|348|436|237|88|141|14|39|5|22|4|8|7;DP_HIST_ALL=3368|7876|3165|776|212|33|16|3|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALL=0|0|0|0|0|0|0|0|0|1|1|0|0|0|0|0|0|0|0|0;AC_AFR=0;AC_AMR=0;AC_ASJ=0;AC_EAS=0;AC_FIN=0;AC_NFE=2;AC_OTH=0;AC_Male=2;AC_Female=0;AN_AFR=1298;AN_AMR=334;AN_ASJ=84;AN_EAS=380;AN_FIN=1460;AN_NFE=4412;AN_OTH=332;AN_Male=4748;AN_Female=3552;AF_AFR=0.00000e+00;AF_AMR=0.00000e+00;AF_ASJ=0.00000e+00;AF_EAS=0.00000e+00;AF_FIN=0.00000e+00;AF_NFE=4.53309e-04;AF_OTH=0.00000e+00;AF_Male=4.21230e-04;AF_Female=0.00000e+00;GC_AFR=649,0,0;GC_AMR=167,0,0;GC_ASJ=42,0,0;GC_EAS=190,0,0;GC_FIN=730,0,0;GC_NFE=2204,2,0;GC_OTH=166,0,0;GC_Male=2372,2,0;GC_Female=1776,0,0;AC_raw=2;AN_raw=30898;AF_raw=6.47291e-05;GC_raw=15447,2,0;GC=4148,2,0;Hom_AFR=0;Hom_AMR=0;Hom_ASJ=0;Hom_EAS=0;Hom_FIN=0;Hom_NFE=0;Hom_OTH=0;Hom_Male=0;Hom_Female=0;Hom_raw=0;Hom=0;POPMAX=NFE;AC_POPMAX=2;AN_POPMAX=4412;AF_POPMAX=4.53309e-04;DP_MEDIAN=11;DREF_MEDIAN=6.29479e-16;GQ_MEDIAN=99;AB_MEDIAN=4.80769e-01;AS_RF=3.30908e-01;AS_FilterStatus=RF;CSQ=A|intergenic_variant|MODIFIER||||||||||||||||1||||SNV|1||||||||||||||||||||||||||||||||||||||||||||
+22	16050115	rs587755077	G	A	10684.53	RF	AC=31;AF=2.54057e-03;AN=12202;BaseQRankSum=1.59000e+00;ClippingRankSum=6.70000e-02;DP=196906;FS=0.00000e+00;InbreedingCoeff=1.40000e-02;MQ=3.37700e+01;MQRankSum=4.06000e-01;QD=8.23000e+00;ReadPosRankSum=3.22000e-01;SOR=4.23100e+00;VQSLOD=-1.16300e+02;VQSR_culprit=MQ;GQ_HIST_ALT=3|6|10|5|3|3|6|13|17|16|2|3|9|12|8|11|5|3|3|14;DP_HIST_ALT=22|95|32|3|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALT=0|0|0|4|6|16|20|8|21|1|28|5|7|7|7|7|8|0|0|0;GQ_HIST_ALL=237|959|984|2740|3098|1328|2215|1483|527|685|442|163|289|52|79|25|61|6|27|39;DP_HIST_ALL=1972|7287|4327|1314|407|79|44|9|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALL=0|0|0|4|6|16|20|8|21|1|28|5|7|7|7|7|8|0|0|0;AC_AFR=30;AC_AMR=1;AC_ASJ=0;AC_EAS=0;AC_FIN=0;AC_NFE=0;AC_OTH=0;AC_Male=16;AC_Female=15;AN_AFR=2236;AN_AMR=436;AN_ASJ=144;AN_EAS=640;AN_FIN=1862;AN_NFE=6410;AN_OTH=474;AN_Male=6874;AN_Female=5328;AF_AFR=1.34168e-02;AF_AMR=2.29358e-03;AF_ASJ=0.00000e+00;AF_EAS=0.00000e+00;AF_FIN=0.00000e+00;AF_NFE=0.00000e+00;AF_OTH=0.00000e+00;AF_Male=2.32761e-03;AF_Female=2.81532e-03;GC_AFR=1088,30,0;GC_AMR=217,1,0;GC_ASJ=72,0,0;GC_EAS=320,0,0;GC_FIN=931,0,0;GC_NFE=3205,0,0;GC_OTH=237,0,0;GC_Male=3421,16,0;GC_Female=2649,15,0;AC_raw=159;AN_raw=30878;AF_raw=5.14930e-03;GC_raw=15287,145,7;GC=6070,31,0;Hom_AFR=0;Hom_AMR=0;Hom_ASJ=0;Hom_EAS=0;Hom_FIN=0;Hom_NFE=0;Hom_OTH=0;Hom_Male=0;Hom_Female=0;Hom_raw=7;Hom=0;POPMAX=AFR;AC_POPMAX=30;AN_POPMAX=2236;AF_POPMAX=1.34168e-02;DP_MEDIAN=7;DREF_MEDIAN=1.74246e-08;GQ_MEDIAN=48;AB_MEDIAN=4.44444e-01;AS_RF=5.02621e-02;AS_FilterStatus=RF;CSQ=A|intergenic_variant|MODIFIER|||||||||||||||rs587755077|1||||SNV|1||||||||||||||||A:0.0064||||||||||||||||||||||||||||
+22	16050116	.	G	C	28395.88	RF	AC=246;AF=2.51431e-02;AN=9784;BaseQRankSum=2.48000e-01;ClippingRankSum=0.00000e+00;DP=201089;FS=0.00000e+00;InbreedingCoeff=-7.09000e-02;MQ=3.23400e+01;MQRankSum=-1.23100e+00;QD=3.27000e+00;ReadPosRankSum=2.48000e-01;SOR=7.16400e+00;VQSLOD=-3.11400e+02;VQSR_culprit=MQ;GQ_HIST_ALT=0|3|6|9|32|41|110|119|73|75|49|48|27|32|38|16|4|9|19|27;DP_HIST_ALT=21|356|285|60|12|3|0|0|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALT=0|0|11|105|184|174|98|40|64|2|30|5|11|8|2|2|0|0|0|0;GQ_HIST_ALL=2616|992|935|2244|2407|1109|1723|1219|458|593|382|175|259|62|105|27|46|11|38|55;DP_HIST_ALL=1838|7215|4403|1404|443|92|50|11|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALL=0|0|11|105|184|174|98|40|64|2|30|5|11|8|2|2|0|0|0|0;AC_AFR=18;AC_AMR=5;AC_ASJ=4;AC_EAS=3;AC_FIN=5;AC_NFE=202;AC_OTH=9;AC_Male=141;AC_Female=105;AN_AFR=2166;AN_AMR=402;AN_ASJ=88;AN_EAS=650;AN_FIN=1722;AN_NFE=4390;AN_OTH=366;AN_Male=5450;AN_Female=4334;AF_AFR=8.31025e-03;AF_AMR=1.24378e-02;AF_ASJ=4.54545e-02;AF_EAS=4.61538e-03;AF_FIN=2.90360e-03;AF_NFE=4.60137e-02;AF_OTH=2.45902e-02;AF_Male=2.58716e-02;AF_Female=2.42270e-02;GC_AFR=1065,18,0;GC_AMR=196,5,0;GC_ASJ=40,4,0;GC_EAS=322,3,0;GC_FIN=856,5,0;GC_NFE=1993,202,0;GC_OTH=174,9,0;GC_Male=2584,141,0;GC_Female=2062,105,0;AC_raw=738;AN_raw=30912;AF_raw=2.38742e-02;GC_raw=14719,736,1;GC=4646,246,0;Hom_AFR=0;Hom_AMR=0;Hom_ASJ=0;Hom_EAS=0;Hom_FIN=0;Hom_NFE=0;Hom_OTH=0;Hom_Male=0;Hom_Female=0;Hom_raw=1;Hom=0;POPMAX=NFE;AC_POPMAX=202;AN_POPMAX=4390;AF_POPMAX=4.60137e-02;DP_MEDIAN=9;DREF_MEDIAN=6.30918e-05;GQ_MEDIAN=42;AB_MEDIAN=2.50000e-01;AS_RF=8.65786e-03;AS_FilterStatus=RF;CSQ=C|intergenic_variant|MODIFIER||||||||||||||||1||||SNV|1||||||||||||||||||||||||||||||||||||||||||||
+22	16050129	.	G	GACA,C	1164.92	PASS	AC=3,0;AF=1.81378e-04,0.00000e+00;AN=16540;BaseQRankSum=-2.24000e-01;ClippingRankSum=-2.63000e-01;DP=230703;FS=8.86700e+00;InbreedingCoeff=5.80000e-03;MQ=3.46800e+01;MQRankSum=1.43000e-01;QD=1.01300e+01;ReadPosRankSum=-2.13000e-01;SOR=3.30000e-02;VQSLOD=-1.37800e+00;VQSR_culprit=SOR;VQSR_NEGATIVE_TRAIN_SITE;GQ_HIST_ALT=0|0|0|0|0|0|0|0|0|0|0|0|0|0|1|0|1|0|0|4,0|0|0|0|0|0|0|0|0|0|0|0|0|0|1|0|0|0|0|0;DP_HIST_ALT=0|3|2|1|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0,0|1|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALT=0|0|0|0|0|0|2|0|1|1|1|0|0|0|0|1|0|0|0|0,0|0|0|0|0|0|0|0|0|0|0|0|1|0|0|0|0|0|0|0;GQ_HIST_ALL=104|464|608|1985|2741|1441|2526|1859|721|1069|690|260|538|62|159|47|92|8|46|68;DP_HIST_ALL=1018|6123|5177|2097|791|161|97|24|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALL=0|0|0|0|0|0|2|0|1|1|1|0|1|0|0|1|0|0|0|0;AC_AFR=0,0;AC_AMR=0,0;AC_ASJ=0,0;AC_EAS=0,0;AC_FIN=0,0;AC_NFE=3,0;AC_OTH=0,0;AC_Male=3,0;AC_Female=0,0;AN_AFR=3614;AN_AMR=528;AN_ASJ=180;AN_EAS=892;AN_FIN=2256;AN_NFE=8466;AN_OTH=604;AN_Male=9308;AN_Female=7232;AF_AFR=0.00000e+00,0.00000e+00;AF_AMR=0.00000e+00,0.00000e+00;AF_ASJ=0.00000e+00,0.00000e+00;AF_EAS=0.00000e+00,0.00000e+00;AF_FIN=0.00000e+00,0.00000e+00;AF_NFE=3.54359e-04,0.00000e+00;AF_OTH=0.00000e+00,0.00000e+00;AF_Male=3.22303e-04,0.00000e+00;AF_Female=0.00000e+00,0.00000e+00;GC_AFR=1807,0,0,0,0,0;GC_AMR=264,0,0,0,0,0;GC_ASJ=90,0,0,0,0,0;GC_EAS=446,0,0,0,0,0;GC_FIN=1128,0,0,0,0,0;GC_NFE=4230,3,0,0,0,0;GC_OTH=302,0,0,0,0,0;GC_Male=4651,3,0,0,0,0;GC_Female=3616,0,0,0,0,0;AC_raw=6,1;AN_raw=30976;AF_raw=1.93698e-04,3.22831e-05;GC_raw=15481,6,0,1,0,0;GC=8267,3,0,0,0,0;Hom_AFR=0,0;Hom_AMR=0,0;Hom_ASJ=0,0;Hom_EAS=0,0;Hom_FIN=0,0;Hom_NFE=0,0;Hom_OTH=0,0;Hom_Male=0,0;Hom_Female=0,0;Hom_raw=0,0;Hom=0,0;POPMAX=NFE,.;AC_POPMAX=3,.;AN_POPMAX=8466,.;AF_POPMAX=3.54359e-04,.;DP_MEDIAN=10,8;DREF_MEDIAN=3.15558e-20,2.51189e-13;GQ_MEDIAN=99,72;AB_MEDIAN=4.41558e-01,6.25000e-01;AS_RF=5.16800e-01,3.29197e-01;AS_FilterStatus=PASS,RF|AC0;CSQ=C|intergenic_variant|MODIFIER||||||||||||||||2||||insertion|1||||||||||||||||||||||||||||||||||||||||||||
+22	16050141	.	C	A	108.57	PASS	AC=1;AF=5.09632e-05;AN=19622;BaseQRankSum=-7.51000e-01;ClippingRankSum=-1.43000e-01;DP=255559;FS=0.00000e+00;InbreedingCoeff=-4.70000e-03;MQ=3.40100e+01;MQRankSum=-3.32000e-01;QD=9.87000e+00;ReadPosRankSum=6.60000e-02;SOR=9.90000e-02;VQSLOD=-3.45100e+01;VQSR_culprit=MQ;GQ_HIST_ALT=0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|1;DP_HIST_ALT=0|0|1|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALT=0|0|0|0|0|0|0|0|0|0|1|0|0|0|0|0|0|0|0|0;GQ_HIST_ALL=90|295|443|1443|2398|1347|2546|2110|845|1318|842|356|727|79|237|59|159|7|90|99;DP_HIST_ALL=626|4935|5582|2741|1103|289|169|45|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALL=0|0|0|0|0|0|0|0|0|0|1|0|0|0|0|0|0|0|0|0;AC_AFR=0;AC_AMR=0;AC_ASJ=0;AC_EAS=0;AC_FIN=0;AC_NFE=1;AC_OTH=0;AC_Male=1;AC_Female=0;AN_AFR=4696;AN_AMR=588;AN_ASJ=206;AN_EAS=1092;AN_FIN=2392;AN_NFE=9986;AN_OTH=662;AN_Male=10956;AN_Female=8666;AF_AFR=0.00000e+00;AF_AMR=0.00000e+00;AF_ASJ=0.00000e+00;AF_EAS=0.00000e+00;AF_FIN=0.00000e+00;AF_NFE=1.00140e-04;AF_OTH=0.00000e+00;AF_Male=9.12742e-05;AF_Female=0.00000e+00;GC_AFR=2348,0,0;GC_AMR=294,0,0;GC_ASJ=103,0,0;GC_EAS=546,0,0;GC_FIN=1196,0,0;GC_NFE=4992,1,0;GC_OTH=331,0,0;GC_Male=5477,1,0;GC_Female=4333,0,0;AC_raw=1;AN_raw=30980;AF_raw=3.22789e-05;GC_raw=15489,1,0;GC=9810,1,0;Hom_AFR=0;Hom_AMR=0;Hom_ASJ=0;Hom_EAS=0;Hom_FIN=0;Hom_NFE=0;Hom_OTH=0;Hom_Male=0;Hom_Female=0;Hom_raw=0;Hom=0;POPMAX=NFE;AC_POPMAX=1;AN_POPMAX=9986;AF_POPMAX=1.00140e-04;DP_MEDIAN=11;DREF_MEDIAN=7.94328e-18;GQ_MEDIAN=99;AB_MEDIAN=5.45455e-01;AS_RF=4.14273e-01;AS_FilterStatus=PASS;CSQ=A|intergenic_variant|MODIFIER||||||||||||||||1||||SNV|1||||||||||||||||||||||||||||||||||||||||||||
+22	16050146	.	A	T	48.32	RF;AC0	AC=0;AF=0.00000e+00;AN=20636;BaseQRankSum=-3.54000e-01;ClippingRankSum=5.50000e-01;DP=264413;FS=2.76200e+00;InbreedingCoeff=-4.10000e-03;MQ=3.73000e+01;MQRankSum=2.00000e+00;QD=6.90000e+00;ReadPosRankSum=2.00000e+00;SOR=1.53600e+00;VQSLOD=-3.42700e+01;VQSR_culprit=MQ;GQ_HIST_ALT=0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|1|0|0|0|0;DP_HIST_ALT=0|1|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALT=0|0|0|0|0|0|0|0|0|0|0|1|0|0|0|0|0|0|0|0;GQ_HIST_ALL=84|258|359|1323|2262|1285|2499|2192|869|1402|937|374|819|84|270|69|176|10|92|126;DP_HIST_ALL=524|4533|5628|2926|1267|363|187|58|4|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALL=0|0|0|0|0|0|0|0|0|0|0|1|0|0|0|0|0|0|0|0;AC_AFR=0;AC_AMR=0;AC_ASJ=0;AC_EAS=0;AC_FIN=0;AC_NFE=0;AC_OTH=0;AC_Male=0;AC_Female=0;AN_AFR=5074;AN_AMR=602;AN_ASJ=216;AN_EAS=1154;AN_FIN=2448;AN_NFE=10458;AN_OTH=684;AN_Male=11480;AN_Female=9156;AF_AFR=0.00000e+00;AF_AMR=0.00000e+00;AF_ASJ=0.00000e+00;AF_EAS=0.00000e+00;AF_FIN=0.00000e+00;AF_NFE=0.00000e+00;AF_OTH=0.00000e+00;AF_Male=0.00000e+00;AF_Female=0.00000e+00;GC_AFR=2537,0,0;GC_AMR=301,0,0;GC_ASJ=108,0,0;GC_EAS=577,0,0;GC_FIN=1224,0,0;GC_NFE=5229,0,0;GC_OTH=342,0,0;GC_Male=5740,0,0;GC_Female=4578,0,0;AC_raw=1;AN_raw=30980;AF_raw=3.22789e-05;GC_raw=15489,1,0;GC=10318,0,0;Hom_AFR=0;Hom_AMR=0;Hom_ASJ=0;Hom_EAS=0;Hom_FIN=0;Hom_NFE=0;Hom_OTH=0;Hom_Male=0;Hom_Female=0;Hom_raw=0;Hom=0;POPMAX=.;AC_POPMAX=.;AN_POPMAX=.;AF_POPMAX=.;DP_MEDIAN=7;DREF_MEDIAN=1.00000e-11;GQ_MEDIAN=78;AB_MEDIAN=5.71429e-01;AS_RF=2.11047e-01;AS_FilterStatus=RF|AC0;CSQ=T|intergenic_variant|MODIFIER||||||||||||||||1||||SNV|1||||||||||||||||||||||||||||||||||||||||||||

--- a/tests/cbcf_data/gnomad_fixed.vcf
+++ b/tests/cbcf_data/gnomad_fixed.vcf
@@ -1,0 +1,200 @@
+##fileformat=VCFv4.2
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=AD,Number=R,Type=Integer,Description="Allelic depths for the ref and alt alleles in the order listed">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read Depth">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=PL,Number=.,Type=Integer,Description="Normalized, Phred-scaled likelihoods for genotypes as defined in the VCF specification">
+##FILTER=<ID=RF,Description="Failed random forests filters (SNV cutoff 0.4, indels cutoff 0.4)">
+##FILTER=<ID=AC0,Description="Allele Count is zero (i.e. no high-confidence genotype (GQ >= 20, DP >= 10, AB => 0.2 for het calls))">
+##FILTER=<ID=InbreedingCoeff,Description="InbreedingCoeff < -0.3">
+##FILTER=<ID=LCR,Description="In a low complexity region">
+##FILTER=<ID=SEGDUP,Description="In a segmental duplication region">
+##FILTER=<ID=PASS,Description="All filters passed for at least one of the alleles at that site (see AS_FilterStatus for allele-specific filter status)">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency among genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##INFO=<ID=BaseQRankSum,Number=1,Type=Float,Description="Z-score from Wilcoxon rank sum test of Alt Vs. Ref base qualities">
+##INFO=<ID=ClippingRankSum,Number=1,Type=Float,Description="Z-score from Wilcoxon rank sum test of Alt vs. Ref number of hard clipped bases">
+##INFO=<ID=DB,Number=0,Type=Flag,Description="dbSNP Membership">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth; some reads may have been filtered">
+##INFO=<ID=FS,Number=1,Type=Float,Description="Phred-scaled p-value using Fisher's exact test to detect strand bias">
+##INFO=<ID=InbreedingCoeff,Number=1,Type=Float,Description="Inbreeding coefficient as estimated from the genotype likelihoods per-sample when compared against the Hardy-Weinberg expectation">
+##INFO=<ID=MQ,Number=1,Type=Float,Description="RMS Mapping Quality">
+##INFO=<ID=MQRankSum,Number=1,Type=Float,Description="Z-score from Wilcoxon rank sum test of Alt vs. Ref read mapping qualities">
+##INFO=<ID=QD,Number=1,Type=Float,Description="Variant Confidence/Quality by Depth">
+##INFO=<ID=ReadPosRankSum,Number=1,Type=Float,Description="Z-score from Wilcoxon rank sum test of Alt vs. Ref read position bias">
+##INFO=<ID=SOR,Number=1,Type=Float,Description="Symmetric Odds Ratio of 2x2 contingency table to detect strand bias">
+##INFO=<ID=VQSLOD,Number=1,Type=Float,Description="Log odds ratio of being a true variant versus being false under the trained VQSR gaussian mixture model (deprecated; see AS_RF)">
+##INFO=<ID=VQSR_culprit,Number=1,Type=String,Description="The annotation which was the worst performing in the VQSR Gaussian mixture model (deprecated; see AS_RF)">
+##INFO=<ID=VQSR_NEGATIVE_TRAIN_SITE,Number=0,Type=Flag,Description="This variant was used to build the negative training set of bad variants for VQSR (deprecated; see AS_RF_NEGATIVE_TRAIN)">
+##INFO=<ID=VQSR_POSITIVE_TRAIN_SITE,Number=0,Type=Flag,Description="This variant was used to build the positive training set of good variants for VQSR (deprecated; see AS_RF_POSITIVE_TRAIN)">
+##INFO=<ID=GQ_HIST_ALT,Number=A,Type=String,Description="Histogram for GQ for each allele; Midpoints of histogram bins: 2.5|7.5|12.5|17.5|22.5|27.5|32.5|37.5|42.5|47.5|52.5|57.5|62.5|67.5|72.5|77.5|82.5|87.5|92.5|97.5">
+##INFO=<ID=DP_HIST_ALT,Number=A,Type=String,Description="Histogram for DP for each allele; Midpoints of histogram bins: 2.5|7.5|12.5|17.5|22.5|27.5|32.5|37.5|42.5|47.5|52.5|57.5|62.5|67.5|72.5|77.5|82.5|87.5|92.5|97.5">
+##INFO=<ID=AB_HIST_ALT,Number=A,Type=String,Description="Histogram for Allele Balance in heterozygous individuals for each allele; 100*AD[i_alt]/sum(AD); Midpoints of histogram bins: 2.5|7.5|12.5|17.5|22.5|27.5|32.5|37.5|42.5|47.5|52.5|57.5|62.5|67.5|72.5|77.5|82.5|87.5|92.5|97.5">
+##INFO=<ID=GQ_HIST_ALL,Number=1,Type=String,Description="Histogram for GQ; Midpoints of histogram bins: 2.5|7.5|12.5|17.5|22.5|27.5|32.5|37.5|42.5|47.5|52.5|57.5|62.5|67.5|72.5|77.5|82.5|87.5|92.5|97.5">
+##INFO=<ID=DP_HIST_ALL,Number=1,Type=String,Description="Histogram for DP; Midpoints of histogram bins: 2.5|7.5|12.5|17.5|22.5|27.5|32.5|37.5|42.5|47.5|52.5|57.5|62.5|67.5|72.5|77.5|82.5|87.5|92.5|97.5">
+##INFO=<ID=AB_HIST_ALL,Number=1,Type=String,Description="Histogram for Allele Balance in heterozygous individuals; 100*AD[i_alt]/sum(AD); Midpoints of histogram bins: 2.5|7.5|12.5|17.5|22.5|27.5|32.5|37.5|42.5|47.5|52.5|57.5|62.5|67.5|72.5|77.5|82.5|87.5|92.5|97.5">
+##INFO=<ID=AC_AFR,Number=A,Type=Integer,Description="Allele count in African/African American genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AC_AMR,Number=A,Type=Integer,Description="Allele count in Admixed American genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AC_ASJ,Number=A,Type=Integer,Description="Allele count in Ashkenazi Jewish genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AC_EAS,Number=A,Type=Integer,Description="Allele count in East Asian genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AC_FIN,Number=A,Type=Integer,Description="Allele count in Finnish genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AC_NFE,Number=A,Type=Integer,Description="Allele count in Non-Finnish European genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AC_OTH,Number=A,Type=Integer,Description="Allele count in Other (population not assigned) genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AC_Male,Number=A,Type=Integer,Description="Allele count in Male genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AC_Female,Number=A,Type=Integer,Description="Allele count in Female genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AN_AFR,Number=1,Type=Integer,Description="Total number of alleles in African/African American called genotypes">
+##INFO=<ID=AN_AMR,Number=1,Type=Integer,Description="Total number of alleles in Admixed American called genotypes">
+##INFO=<ID=AN_ASJ,Number=1,Type=Integer,Description="Total number of alleles in Ashkenazi Jewish called genotypes">
+##INFO=<ID=AN_EAS,Number=1,Type=Integer,Description="Total number of alleles in East Asian called genotypes">
+##INFO=<ID=AN_FIN,Number=1,Type=Integer,Description="Total number of alleles in Finnish called genotypes">
+##INFO=<ID=AN_NFE,Number=1,Type=Integer,Description="Total number of alleles in Non-Finnish European called genotypes">
+##INFO=<ID=AN_OTH,Number=1,Type=Integer,Description="Total number of alleles in Other (population not assigned) called genotypes">
+##INFO=<ID=AN_Male,Number=1,Type=Integer,Description="Total number of alleles in Male called genotypes">
+##INFO=<ID=AN_Female,Number=1,Type=Integer,Description="Total number of alleles in Female called genotypes">
+##INFO=<ID=AF_AFR,Number=A,Type=Float,Description="Allele Frequency among African/African American genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF_AMR,Number=A,Type=Float,Description="Allele Frequency among Admixed American genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF_ASJ,Number=A,Type=Float,Description="Allele Frequency among Ashkenazi Jewish genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF_EAS,Number=A,Type=Float,Description="Allele Frequency among East Asian genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF_FIN,Number=A,Type=Float,Description="Allele Frequency among Finnish genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF_NFE,Number=A,Type=Float,Description="Allele Frequency among Non-Finnish European genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF_OTH,Number=A,Type=Float,Description="Allele Frequency among Other (population not assigned) genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF_Male,Number=A,Type=Float,Description="Allele Frequency among Male genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF_Female,Number=A,Type=Float,Description="Allele Frequency among Female genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=GC_AFR,Number=.,Type=Integer,Description="Count of African/African American individuals for each genotype">
+##INFO=<ID=GC_AMR,Number=.,Type=Integer,Description="Count of Admixed American individuals for each genotype">
+##INFO=<ID=GC_ASJ,Number=.,Type=Integer,Description="Count of Ashkenazi Jewish individuals for each genotype">
+##INFO=<ID=GC_EAS,Number=.,Type=Integer,Description="Count of East Asian individuals for each genotype">
+##INFO=<ID=GC_FIN,Number=.,Type=Integer,Description="Count of Finnish individuals for each genotype">
+##INFO=<ID=GC_NFE,Number=.,Type=Integer,Description="Count of Non-Finnish European individuals for each genotype">
+##INFO=<ID=GC_OTH,Number=.,Type=Integer,Description="Count of Other (population not assigned) individuals for each genotype">
+##INFO=<ID=GC_Male,Number=.,Type=Integer,Description="Count of Male individuals for each genotype">
+##INFO=<ID=GC_Female,Number=.,Type=Integer,Description="Count of Female individuals for each genotype">
+##INFO=<ID=AC_raw,Number=A,Type=Integer,Description="Allele counts before filtering low-confidence genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AN_raw,Number=1,Type=Integer,Description="Total number of alleles before filtering low-confidence genotypes">
+##INFO=<ID=AF_raw,Number=A,Type=Float,Description="Allele frequency before filtering low-confidence genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=GC_raw,Number=.,Type=Integer,Description="Raw count of individuals for each genotype before filtering low-confidence genotypes">
+##INFO=<ID=GC,Number=.,Type=Integer,Description="Count of individuals for each genotype">
+##INFO=<ID=Hom_AFR,Number=A,Type=Integer,Description="Count of homozygous African/African American individuals">
+##INFO=<ID=Hom_AMR,Number=A,Type=Integer,Description="Count of homozygous Admixed American individuals">
+##INFO=<ID=Hom_ASJ,Number=A,Type=Integer,Description="Count of homozygous Ashkenazi Jewish individuals">
+##INFO=<ID=Hom_EAS,Number=A,Type=Integer,Description="Count of homozygous East Asian individuals">
+##INFO=<ID=Hom_FIN,Number=A,Type=Integer,Description="Count of homozygous Finnish individuals">
+##INFO=<ID=Hom_NFE,Number=A,Type=Integer,Description="Count of homozygous Non-Finnish European individuals">
+##INFO=<ID=Hom_OTH,Number=A,Type=Integer,Description="Count of homozygous Other (population not assigned) individuals">
+##INFO=<ID=Hom_Male,Number=A,Type=Integer,Description="Count of homozygous Male individuals">
+##INFO=<ID=Hom_Female,Number=A,Type=Integer,Description="Count of homozygous Female individuals">
+##INFO=<ID=Hom_raw,Number=A,Type=Integer,Description="Count of homozygous individuals in raw genotypes before filtering low-confidence genotypes">
+##INFO=<ID=Hom,Number=A,Type=Integer,Description="Count of homozygous individuals">
+##INFO=<ID=STAR_AC,Number=1,Type=Integer,Description="AC of deletions spanning this position">
+##INFO=<ID=STAR_AC_raw,Number=1,Type=Integer,Description="Allele counts of deletions spanning this position before filtering low-confidence genotypes">
+##INFO=<ID=STAR_Hom,Number=1,Type=Integer,Description="Count of individuals homozygous for a deletion spanning this position">
+##INFO=<ID=POPMAX,Number=A,Type=String,Description="Population with max AF">
+##INFO=<ID=AC_POPMAX,Number=A,Type=Integer,Description="AC in the population with the max AF">
+##INFO=<ID=AN_POPMAX,Number=A,Type=Integer,Description="AN in the population with the max AF">
+##INFO=<ID=AF_POPMAX,Number=A,Type=Float,Description="Maximum Allele Frequency across populations (excluding OTH)">
+##INFO=<ID=DP_MEDIAN,Number=A,Type=Integer,Description="Median DP in carriers of each allele">
+##INFO=<ID=DREF_MEDIAN,Number=A,Type=Float,Description="Median dosage of homozygous reference in carriers of each allele">
+##INFO=<ID=GQ_MEDIAN,Number=A,Type=Integer,Description="Median GQ in carriers of each allele">
+##INFO=<ID=AB_MEDIAN,Number=A,Type=Float,Description="Median allele balance in heterozygote carriers of each allele">
+##INFO=<ID=AS_RF,Number=A,Type=Float,Description="Random Forests probability for each allele">
+##INFO=<ID=AS_FilterStatus,Number=A,Type=String,Description="Random Forests filter status for each allele">
+##INFO=<ID=AS_RF_POSITIVE_TRAIN,Number=.,Type=Integer,Description="Contains the indices of all alleles used as positive examples during training of random forests">
+##INFO=<ID=AS_RF_NEGATIVE_TRAIN,Number=.,Type=Integer,Description="Contains the indices of all alleles used as negative examples during training of random forests">
+##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|EXON|INTRON|HGVSc|HGVSp|cDNA_position|CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|ALLELE_NUM|DISTANCE|STRAND|FLAGS|VARIANT_CLASS|MINIMISED|SYMBOL_SOURCE|HGNC_ID|CANONICAL|TSL|APPRIS|CCDS|ENSP|SWISSPROT|TREMBL|UNIPARC|GENE_PHENO|SIFT|PolyPhen|DOMAINS|HGVS_OFFSET|GMAF|AFR_MAF|AMR_MAF|EAS_MAF|EUR_MAF|SAS_MAF|AA_MAF|EA_MAF|ExAC_MAF|ExAC_Adj_MAF|ExAC_AFR_MAF|ExAC_AMR_MAF|ExAC_EAS_MAF|ExAC_FIN_MAF|ExAC_NFE_MAF|ExAC_OTH_MAF|ExAC_SAS_MAF|CLIN_SIG|SOMATIC|PHENO|PUBMED|MOTIF_NAME|MOTIF_POS|HIGH_INF_POS|MOTIF_SCORE_CHANGE|LoF|LoF_filter|LoF_flags|LoF_info">
+##contig=<ID=1,length=249250621>
+##contig=<ID=2,length=243199373>
+##contig=<ID=3,length=198022430>
+##contig=<ID=4,length=191154276>
+##contig=<ID=5,length=180915260>
+##contig=<ID=6,length=171115067>
+##contig=<ID=7,length=159138663>
+##contig=<ID=8,length=146364022>
+##contig=<ID=9,length=141213431>
+##contig=<ID=10,length=135534747>
+##contig=<ID=11,length=135006516>
+##contig=<ID=12,length=133851895>
+##contig=<ID=13,length=115169878>
+##contig=<ID=14,length=107349540>
+##contig=<ID=15,length=102531392>
+##contig=<ID=16,length=90354753>
+##contig=<ID=17,length=81195210>
+##contig=<ID=18,length=78077248>
+##contig=<ID=19,length=59128983>
+##contig=<ID=20,length=63025520>
+##contig=<ID=21,length=48129895>
+##contig=<ID=22,length=51304566>
+##contig=<ID=X,length=155270560>
+##contig=<ID=Y,length=59373566>
+##contig=<ID=MT,length=16569>
+##contig=<ID=GL000207.1,length=4262>
+##contig=<ID=GL000226.1,length=15008>
+##contig=<ID=GL000229.1,length=19913>
+##contig=<ID=GL000231.1,length=27386>
+##contig=<ID=GL000210.1,length=27682>
+##contig=<ID=GL000239.1,length=33824>
+##contig=<ID=GL000235.1,length=34474>
+##contig=<ID=GL000201.1,length=36148>
+##contig=<ID=GL000247.1,length=36422>
+##contig=<ID=GL000245.1,length=36651>
+##contig=<ID=GL000197.1,length=37175>
+##contig=<ID=GL000203.1,length=37498>
+##contig=<ID=GL000246.1,length=38154>
+##contig=<ID=GL000249.1,length=38502>
+##contig=<ID=GL000196.1,length=38914>
+##contig=<ID=GL000248.1,length=39786>
+##contig=<ID=GL000244.1,length=39929>
+##contig=<ID=GL000238.1,length=39939>
+##contig=<ID=GL000202.1,length=40103>
+##contig=<ID=GL000234.1,length=40531>
+##contig=<ID=GL000232.1,length=40652>
+##contig=<ID=GL000206.1,length=41001>
+##contig=<ID=GL000240.1,length=41933>
+##contig=<ID=GL000236.1,length=41934>
+##contig=<ID=GL000241.1,length=42152>
+##contig=<ID=GL000243.1,length=43341>
+##contig=<ID=GL000242.1,length=43523>
+##contig=<ID=GL000230.1,length=43691>
+##contig=<ID=GL000237.1,length=45867>
+##contig=<ID=GL000233.1,length=45941>
+##contig=<ID=GL000204.1,length=81310>
+##contig=<ID=GL000198.1,length=90085>
+##contig=<ID=GL000208.1,length=92689>
+##contig=<ID=GL000191.1,length=106433>
+##contig=<ID=GL000227.1,length=128374>
+##contig=<ID=GL000228.1,length=129120>
+##contig=<ID=GL000214.1,length=137718>
+##contig=<ID=GL000221.1,length=155397>
+##contig=<ID=GL000209.1,length=159169>
+##contig=<ID=GL000218.1,length=161147>
+##contig=<ID=GL000220.1,length=161802>
+##contig=<ID=GL000213.1,length=164239>
+##contig=<ID=GL000211.1,length=166566>
+##contig=<ID=GL000199.1,length=169874>
+##contig=<ID=GL000217.1,length=172149>
+##contig=<ID=GL000216.1,length=172294>
+##contig=<ID=GL000215.1,length=172545>
+##contig=<ID=GL000205.1,length=174588>
+##contig=<ID=GL000219.1,length=179198>
+##contig=<ID=GL000224.1,length=179693>
+##contig=<ID=GL000223.1,length=180455>
+##contig=<ID=GL000195.1,length=182896>
+##contig=<ID=GL000212.1,length=186858>
+##contig=<ID=GL000222.1,length=186861>
+##contig=<ID=GL000200.1,length=187035>
+##contig=<ID=GL000193.1,length=189789>
+##contig=<ID=GL000194.1,length=191469>
+##contig=<ID=GL000225.1,length=211173>
+##contig=<ID=GL000192.1,length=547496>
+##contig=<ID=NC_007605,length=171823>
+##reference=file:///seq/references/Homo_sapiens_assembly19/v1/Homo_sapiens_assembly19.fasta
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+22	16050036	rs374742143	A	C	442156.34	RF	AC=67;AF=4.29487e-01;AN=156;BaseQRankSum=7.36000e-01;ClippingRankSum=2.96000e-01;DB;DP=50165;FS=7.05600e+00;InbreedingCoeff=3.82000e-01;MQ=2.71500e+01;MQRankSum=-1.02600e+00;QD=2.47500e+01;ReadPosRankSum=-2.11000e-01;SOR=1.26750e+01;VQSLOD=-9.58600e+02;VQSR_culprit=MQ;GQ_HIST_ALT=16|1279|299|254|155|24|16|28|50|135|78|4|6|11|32|43|6|4|3|35;DP_HIST_ALT=1769|653|51|5|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALT=0|0|0|2|5|24|36|11|89|2|125|31|61|85|24|60|34|8|3|7;GQ_HIST_ALL=2359|2810|730|651|296|51|34|33|53|135|78|4|6|11|32|43|6|4|3|35;DP_HIST_ALL=5518|1756|94|6|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALL=0|0|0|2|5|24|36|11|89|2|125|31|61|85|24|60|34|8|3|7;AC_AFR=3;AC_AMR=7;AC_ASJ=0;AC_EAS=0;AC_FIN=50;AC_NFE=3;AC_OTH=4;AC_Male=32;AC_Female=35;AN_AFR=14;AN_AMR=10;AN_ASJ=0;AN_EAS=0;AN_FIN=84;AN_NFE=42;AN_OTH=6;AN_Male=80;AN_Female=76;AF_AFR=2.14286e-01;AF_AMR=7.00000e-01;AF_ASJ=.;AF_EAS=.;AF_FIN=5.95238e-01;AF_NFE=7.14286e-02;AF_OTH=6.66667e-01;AF_Male=4.00000e-01;AF_Female=4.60526e-01;GC_AFR=4,3,0;GC_AMR=0,3,2;GC_ASJ=0,0,0;GC_EAS=0,0,0;GC_FIN=4,26,12;GC_NFE=18,3,0;GC_OTH=1,0,2;GC_Male=16,16,8;GC_Female=11,19,8;AC_raw=4349;AN_raw=14748;AF_raw=2.94887e-01;GC_raw=4896,607,1871;GC=27,35,16;Hom_AFR=0;Hom_AMR=2;Hom_ASJ=0;Hom_EAS=0;Hom_FIN=12;Hom_NFE=0;Hom_OTH=2;Hom_Male=8;Hom_Female=8;Hom_raw=1871;Hom=16;POPMAX=AMR;AC_POPMAX=7;AN_POPMAX=10;AF_POPMAX=7.00000e-01;DP_MEDIAN=3;DREF_MEDIAN=5.60406e-10;GQ_MEDIAN=12;AB_MEDIAN=5.55556e-01;AS_RF=4.71609e-02;AS_FilterStatus=RF;CSQ=C|intergenic_variant|MODIFIER|||||||||||||||rs374742143|1||||SNV|1||||||||||||||||||||||||||||||||||||||||||||
+22	16050068	.	A	G	82.46	RF;AC0	AC=0;AF=0.00000e+00;AN=2708;DP=111486;FS=0.00000e+00;InbreedingCoeff=-3.63000e-02;MQ=3.20200e+01;QD=1.64900e+01;SOR=3.61100e+00;VQSLOD=-9.28900e+01;VQSR_culprit=MQ;GQ_HIST_ALT=0|0|0|1|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0;DP_HIST_ALT=0|1|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALT=0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0;GQ_HIST_ALL=1227|4189|2184|3537|2071|618|693|346|97|92|61|9|18|0|7|4|4|0|0|0;DP_HIST_ALL=7502|6289|1163|169|26|8|0|0|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALL=0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0;AC_AFR=0;AC_AMR=0;AC_ASJ=0;AC_EAS=0;AC_FIN=0;AC_NFE=0;AC_OTH=0;AC_Male=0;AC_Female=0;AN_AFR=280;AN_AMR=162;AN_ASJ=34;AN_EAS=74;AN_FIN=748;AN_NFE=1300;AN_OTH=110;AN_Male=1584;AN_Female=1124;AF_AFR=0.00000e+00;AF_AMR=0.00000e+00;AF_ASJ=0.00000e+00;AF_EAS=0.00000e+00;AF_FIN=0.00000e+00;AF_NFE=0.00000e+00;AF_OTH=0.00000e+00;AF_Male=0.00000e+00;AF_Female=0.00000e+00;GC_AFR=140,0,0;GC_AMR=81,0,0;GC_ASJ=17,0,0;GC_EAS=37,0,0;GC_FIN=374,0,0;GC_NFE=650,0,0;GC_OTH=55,0,0;GC_Male=792,0,0;GC_Female=562,0,0;AC_raw=2;AN_raw=30314;AF_raw=6.59761e-05;GC_raw=15156,0,1;GC=1354,0,0;Hom_AFR=0;Hom_AMR=0;Hom_ASJ=0;Hom_EAS=0;Hom_FIN=0;Hom_NFE=0;Hom_OTH=0;Hom_Male=0;Hom_Female=0;Hom_raw=1;Hom=0;POPMAX=.;AC_POPMAX=.;AN_POPMAX=.;AF_POPMAX=.;DP_MEDIAN=5;DREF_MEDIAN=1.22034e-16;GQ_MEDIAN=15;AB_MEDIAN=5.00000e-01;AS_RF=5.87186e-02;AS_FilterStatus=RF|AC0;CSQ=G|intergenic_variant|MODIFIER||||||||||||||||1||||SNV|1||||||||||||||||||||||||||||||||||||||||||||
+22	16050069	.	C	T	43.44	RF;AC0	AC=0;AF=0.00000e+00;AN=2802;BaseQRankSum=7.20000e-01;ClippingRankSum=-1.38000e+00;DP=112972;FS=0.00000e+00;InbreedingCoeff=-3.70000e-02;MQ=3.67700e+01;MQRankSum=7.20000e-01;QD=7.24000e+00;ReadPosRankSum=1.38000e+00;SOR=1.32900e+00;VQSLOD=-3.27400e+01;VQSR_culprit=MQ;GQ_HIST_ALT=0|0|0|0|0|0|0|1|0|0|0|0|0|0|0|0|0|0|0|0;DP_HIST_ALT=0|1|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALT=0|0|0|0|0|0|0|0|0|0|0|0|0|1|0|0|0|0|0|0;GQ_HIST_ALL=1200|4098|2219|3540|2117|622|710|352|104|101|64|10|20|1|8|3|4|0|0|0;DP_HIST_ALL=7405|6348|1203|181|28|8|0|0|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALL=0|0|0|0|0|0|0|0|0|0|0|0|0|1|0|0|0|0|0|0;AC_AFR=0;AC_AMR=0;AC_ASJ=0;AC_EAS=0;AC_FIN=0;AC_NFE=0;AC_OTH=0;AC_Male=0;AC_Female=0;AN_AFR=296;AN_AMR=164;AN_ASJ=36;AN_EAS=70;AN_FIN=766;AN_NFE=1354;AN_OTH=116;AN_Male=1638;AN_Female=1164;AF_AFR=0.00000e+00;AF_AMR=0.00000e+00;AF_ASJ=0.00000e+00;AF_EAS=0.00000e+00;AF_FIN=0.00000e+00;AF_NFE=0.00000e+00;AF_OTH=0.00000e+00;AF_Male=0.00000e+00;AF_Female=0.00000e+00;GC_AFR=148,0,0;GC_AMR=82,0,0;GC_ASJ=18,0,0;GC_EAS=35,0,0;GC_FIN=383,0,0;GC_NFE=677,0,0;GC_OTH=58,0,0;GC_Male=819,0,0;GC_Female=582,0,0;AC_raw=1;AN_raw=30346;AF_raw=3.29533e-05;GC_raw=15172,1,0;GC=1401,0,0;Hom_AFR=0;Hom_AMR=0;Hom_ASJ=0;Hom_EAS=0;Hom_FIN=0;Hom_NFE=0;Hom_OTH=0;Hom_Male=0;Hom_Female=0;Hom_raw=0;Hom=0;POPMAX=.;AC_POPMAX=.;AN_POPMAX=.;AF_POPMAX=.;DP_MEDIAN=6;DREF_MEDIAN=3.16178e-11;GQ_MEDIAN=38;AB_MEDIAN=6.66667e-01;AS_RF=9.22976e-02;AS_FilterStatus=RF|AC0;CSQ=T|intergenic_variant|MODIFIER||||||||||||||||1||||SNV|1||||||||||||||||||||||||||||||||||||||||||||
+22	16050098	.	G	A	242.82	RF	AC=2;AF=2.40964e-04;AN=8300;BaseQRankSum=2.45000e+00;ClippingRankSum=1.03000e-01;DP=167171;FS=0.00000e+00;InbreedingCoeff=-1.46000e-02;MQ=3.06100e+01;MQRankSum=-9.35000e-01;QD=1.05600e+01;ReadPosRankSum=6.60000e-01;SOR=3.84000e-01;VQSLOD=-4.11500e+01;VQSR_culprit=MQ;GQ_HIST_ALT=0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|2;DP_HIST_ALT=0|0|2|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALT=0|0|0|0|0|0|0|0|0|1|1|0|0|0|0|0|0|0|0|0;GQ_HIST_ALL=350|1697|1483|3462|3106|1262|1746|994|348|436|237|88|141|14|39|5|22|4|8|7;DP_HIST_ALL=3368|7876|3165|776|212|33|16|3|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALL=0|0|0|0|0|0|0|0|0|1|1|0|0|0|0|0|0|0|0|0;AC_AFR=0;AC_AMR=0;AC_ASJ=0;AC_EAS=0;AC_FIN=0;AC_NFE=2;AC_OTH=0;AC_Male=2;AC_Female=0;AN_AFR=1298;AN_AMR=334;AN_ASJ=84;AN_EAS=380;AN_FIN=1460;AN_NFE=4412;AN_OTH=332;AN_Male=4748;AN_Female=3552;AF_AFR=0.00000e+00;AF_AMR=0.00000e+00;AF_ASJ=0.00000e+00;AF_EAS=0.00000e+00;AF_FIN=0.00000e+00;AF_NFE=4.53309e-04;AF_OTH=0.00000e+00;AF_Male=4.21230e-04;AF_Female=0.00000e+00;GC_AFR=649,0,0;GC_AMR=167,0,0;GC_ASJ=42,0,0;GC_EAS=190,0,0;GC_FIN=730,0,0;GC_NFE=2204,2,0;GC_OTH=166,0,0;GC_Male=2372,2,0;GC_Female=1776,0,0;AC_raw=2;AN_raw=30898;AF_raw=6.47291e-05;GC_raw=15447,2,0;GC=4148,2,0;Hom_AFR=0;Hom_AMR=0;Hom_ASJ=0;Hom_EAS=0;Hom_FIN=0;Hom_NFE=0;Hom_OTH=0;Hom_Male=0;Hom_Female=0;Hom_raw=0;Hom=0;POPMAX=NFE;AC_POPMAX=2;AN_POPMAX=4412;AF_POPMAX=4.53309e-04;DP_MEDIAN=11;DREF_MEDIAN=6.29479e-16;GQ_MEDIAN=99;AB_MEDIAN=4.80769e-01;AS_RF=3.30908e-01;AS_FilterStatus=RF;CSQ=A|intergenic_variant|MODIFIER||||||||||||||||1||||SNV|1||||||||||||||||||||||||||||||||||||||||||||
+22	16050115	rs587755077	G	A	10684.53	RF	AC=31;AF=2.54057e-03;AN=12202;BaseQRankSum=1.59000e+00;ClippingRankSum=6.70000e-02;DP=196906;FS=0.00000e+00;InbreedingCoeff=1.40000e-02;MQ=3.37700e+01;MQRankSum=4.06000e-01;QD=8.23000e+00;ReadPosRankSum=3.22000e-01;SOR=4.23100e+00;VQSLOD=-1.16300e+02;VQSR_culprit=MQ;GQ_HIST_ALT=3|6|10|5|3|3|6|13|17|16|2|3|9|12|8|11|5|3|3|14;DP_HIST_ALT=22|95|32|3|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALT=0|0|0|4|6|16|20|8|21|1|28|5|7|7|7|7|8|0|0|0;GQ_HIST_ALL=237|959|984|2740|3098|1328|2215|1483|527|685|442|163|289|52|79|25|61|6|27|39;DP_HIST_ALL=1972|7287|4327|1314|407|79|44|9|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALL=0|0|0|4|6|16|20|8|21|1|28|5|7|7|7|7|8|0|0|0;AC_AFR=30;AC_AMR=1;AC_ASJ=0;AC_EAS=0;AC_FIN=0;AC_NFE=0;AC_OTH=0;AC_Male=16;AC_Female=15;AN_AFR=2236;AN_AMR=436;AN_ASJ=144;AN_EAS=640;AN_FIN=1862;AN_NFE=6410;AN_OTH=474;AN_Male=6874;AN_Female=5328;AF_AFR=1.34168e-02;AF_AMR=2.29358e-03;AF_ASJ=0.00000e+00;AF_EAS=0.00000e+00;AF_FIN=0.00000e+00;AF_NFE=0.00000e+00;AF_OTH=0.00000e+00;AF_Male=2.32761e-03;AF_Female=2.81532e-03;GC_AFR=1088,30,0;GC_AMR=217,1,0;GC_ASJ=72,0,0;GC_EAS=320,0,0;GC_FIN=931,0,0;GC_NFE=3205,0,0;GC_OTH=237,0,0;GC_Male=3421,16,0;GC_Female=2649,15,0;AC_raw=159;AN_raw=30878;AF_raw=5.14930e-03;GC_raw=15287,145,7;GC=6070,31,0;Hom_AFR=0;Hom_AMR=0;Hom_ASJ=0;Hom_EAS=0;Hom_FIN=0;Hom_NFE=0;Hom_OTH=0;Hom_Male=0;Hom_Female=0;Hom_raw=7;Hom=0;POPMAX=AFR;AC_POPMAX=30;AN_POPMAX=2236;AF_POPMAX=1.34168e-02;DP_MEDIAN=7;DREF_MEDIAN=1.74246e-08;GQ_MEDIAN=48;AB_MEDIAN=4.44444e-01;AS_RF=5.02621e-02;AS_FilterStatus=RF;CSQ=A|intergenic_variant|MODIFIER|||||||||||||||rs587755077|1||||SNV|1||||||||||||||||A:0.0064||||||||||||||||||||||||||||
+22	16050116	.	G	C	28395.88	RF	AC=246;AF=2.51431e-02;AN=9784;BaseQRankSum=2.48000e-01;ClippingRankSum=0.00000e+00;DP=201089;FS=0.00000e+00;InbreedingCoeff=-7.09000e-02;MQ=3.23400e+01;MQRankSum=-1.23100e+00;QD=3.27000e+00;ReadPosRankSum=2.48000e-01;SOR=7.16400e+00;VQSLOD=-3.11400e+02;VQSR_culprit=MQ;GQ_HIST_ALT=0|3|6|9|32|41|110|119|73|75|49|48|27|32|38|16|4|9|19|27;DP_HIST_ALT=21|356|285|60|12|3|0|0|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALT=0|0|11|105|184|174|98|40|64|2|30|5|11|8|2|2|0|0|0|0;GQ_HIST_ALL=2616|992|935|2244|2407|1109|1723|1219|458|593|382|175|259|62|105|27|46|11|38|55;DP_HIST_ALL=1838|7215|4403|1404|443|92|50|11|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALL=0|0|11|105|184|174|98|40|64|2|30|5|11|8|2|2|0|0|0|0;AC_AFR=18;AC_AMR=5;AC_ASJ=4;AC_EAS=3;AC_FIN=5;AC_NFE=202;AC_OTH=9;AC_Male=141;AC_Female=105;AN_AFR=2166;AN_AMR=402;AN_ASJ=88;AN_EAS=650;AN_FIN=1722;AN_NFE=4390;AN_OTH=366;AN_Male=5450;AN_Female=4334;AF_AFR=8.31025e-03;AF_AMR=1.24378e-02;AF_ASJ=4.54545e-02;AF_EAS=4.61538e-03;AF_FIN=2.90360e-03;AF_NFE=4.60137e-02;AF_OTH=2.45902e-02;AF_Male=2.58716e-02;AF_Female=2.42270e-02;GC_AFR=1065,18,0;GC_AMR=196,5,0;GC_ASJ=40,4,0;GC_EAS=322,3,0;GC_FIN=856,5,0;GC_NFE=1993,202,0;GC_OTH=174,9,0;GC_Male=2584,141,0;GC_Female=2062,105,0;AC_raw=738;AN_raw=30912;AF_raw=2.38742e-02;GC_raw=14719,736,1;GC=4646,246,0;Hom_AFR=0;Hom_AMR=0;Hom_ASJ=0;Hom_EAS=0;Hom_FIN=0;Hom_NFE=0;Hom_OTH=0;Hom_Male=0;Hom_Female=0;Hom_raw=1;Hom=0;POPMAX=NFE;AC_POPMAX=202;AN_POPMAX=4390;AF_POPMAX=4.60137e-02;DP_MEDIAN=9;DREF_MEDIAN=6.30918e-05;GQ_MEDIAN=42;AB_MEDIAN=2.50000e-01;AS_RF=8.65786e-03;AS_FilterStatus=RF;CSQ=C|intergenic_variant|MODIFIER||||||||||||||||1||||SNV|1||||||||||||||||||||||||||||||||||||||||||||
+22	16050129	.	G	GACA,C	1164.92	PASS	AC=3,0;AF=1.81378e-04,0.00000e+00;AN=16540;BaseQRankSum=-2.24000e-01;ClippingRankSum=-2.63000e-01;DP=230703;FS=8.86700e+00;InbreedingCoeff=5.80000e-03;MQ=3.46800e+01;MQRankSum=1.43000e-01;QD=1.01300e+01;ReadPosRankSum=-2.13000e-01;SOR=3.30000e-02;VQSLOD=-1.37800e+00;VQSR_culprit=SOR;VQSR_NEGATIVE_TRAIN_SITE;GQ_HIST_ALT=0|0|0|0|0|0|0|0|0|0|0|0|0|0|1|0|1|0|0|4,0|0|0|0|0|0|0|0|0|0|0|0|0|0|1|0|0|0|0|0;DP_HIST_ALT=0|3|2|1|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0,0|1|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALT=0|0|0|0|0|0|2|0|1|1|1|0|0|0|0|1|0|0|0|0,0|0|0|0|0|0|0|0|0|0|0|0|1|0|0|0|0|0|0|0;GQ_HIST_ALL=104|464|608|1985|2741|1441|2526|1859|721|1069|690|260|538|62|159|47|92|8|46|68;DP_HIST_ALL=1018|6123|5177|2097|791|161|97|24|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALL=0|0|0|0|0|0|2|0|1|1|1|0|1|0|0|1|0|0|0|0;AC_AFR=0,0;AC_AMR=0,0;AC_ASJ=0,0;AC_EAS=0,0;AC_FIN=0,0;AC_NFE=3,0;AC_OTH=0,0;AC_Male=3,0;AC_Female=0,0;AN_AFR=3614;AN_AMR=528;AN_ASJ=180;AN_EAS=892;AN_FIN=2256;AN_NFE=8466;AN_OTH=604;AN_Male=9308;AN_Female=7232;AF_AFR=0.00000e+00,0.00000e+00;AF_AMR=0.00000e+00,0.00000e+00;AF_ASJ=0.00000e+00,0.00000e+00;AF_EAS=0.00000e+00,0.00000e+00;AF_FIN=0.00000e+00,0.00000e+00;AF_NFE=3.54359e-04,0.00000e+00;AF_OTH=0.00000e+00,0.00000e+00;AF_Male=3.22303e-04,0.00000e+00;AF_Female=0.00000e+00,0.00000e+00;GC_AFR=1807,0,0,0,0,0;GC_AMR=264,0,0,0,0,0;GC_ASJ=90,0,0,0,0,0;GC_EAS=446,0,0,0,0,0;GC_FIN=1128,0,0,0,0,0;GC_NFE=4230,3,0,0,0,0;GC_OTH=302,0,0,0,0,0;GC_Male=4651,3,0,0,0,0;GC_Female=3616,0,0,0,0,0;AC_raw=6,1;AN_raw=30976;AF_raw=1.93698e-04,3.22831e-05;GC_raw=15481,6,0,1,0,0;GC=8267,3,0,0,0,0;Hom_AFR=0,0;Hom_AMR=0,0;Hom_ASJ=0,0;Hom_EAS=0,0;Hom_FIN=0,0;Hom_NFE=0,0;Hom_OTH=0,0;Hom_Male=0,0;Hom_Female=0,0;Hom_raw=0,0;Hom=0,0;POPMAX=NFE,.;AC_POPMAX=3,.;AN_POPMAX=8466,.;AF_POPMAX=3.54359e-04,.;DP_MEDIAN=10,8;DREF_MEDIAN=3.15558e-20,2.51189e-13;GQ_MEDIAN=99,72;AB_MEDIAN=4.41558e-01,6.25000e-01;AS_RF=5.16800e-01,3.29197e-01;AS_FilterStatus=PASS,RF|AC0;CSQ=C|intergenic_variant|MODIFIER||||||||||||||||2||||insertion|1||||||||||||||||||||||||||||||||||||||||||||
+22	16050141	.	C	A	108.57	PASS	AC=1;AF=5.09632e-05;AN=19622;BaseQRankSum=-7.51000e-01;ClippingRankSum=-1.43000e-01;DP=255559;FS=0.00000e+00;InbreedingCoeff=-4.70000e-03;MQ=3.40100e+01;MQRankSum=-3.32000e-01;QD=9.87000e+00;ReadPosRankSum=6.60000e-02;SOR=9.90000e-02;VQSLOD=-3.45100e+01;VQSR_culprit=MQ;GQ_HIST_ALT=0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|1;DP_HIST_ALT=0|0|1|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALT=0|0|0|0|0|0|0|0|0|0|1|0|0|0|0|0|0|0|0|0;GQ_HIST_ALL=90|295|443|1443|2398|1347|2546|2110|845|1318|842|356|727|79|237|59|159|7|90|99;DP_HIST_ALL=626|4935|5582|2741|1103|289|169|45|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALL=0|0|0|0|0|0|0|0|0|0|1|0|0|0|0|0|0|0|0|0;AC_AFR=0;AC_AMR=0;AC_ASJ=0;AC_EAS=0;AC_FIN=0;AC_NFE=1;AC_OTH=0;AC_Male=1;AC_Female=0;AN_AFR=4696;AN_AMR=588;AN_ASJ=206;AN_EAS=1092;AN_FIN=2392;AN_NFE=9986;AN_OTH=662;AN_Male=10956;AN_Female=8666;AF_AFR=0.00000e+00;AF_AMR=0.00000e+00;AF_ASJ=0.00000e+00;AF_EAS=0.00000e+00;AF_FIN=0.00000e+00;AF_NFE=1.00140e-04;AF_OTH=0.00000e+00;AF_Male=9.12742e-05;AF_Female=0.00000e+00;GC_AFR=2348,0,0;GC_AMR=294,0,0;GC_ASJ=103,0,0;GC_EAS=546,0,0;GC_FIN=1196,0,0;GC_NFE=4992,1,0;GC_OTH=331,0,0;GC_Male=5477,1,0;GC_Female=4333,0,0;AC_raw=1;AN_raw=30980;AF_raw=3.22789e-05;GC_raw=15489,1,0;GC=9810,1,0;Hom_AFR=0;Hom_AMR=0;Hom_ASJ=0;Hom_EAS=0;Hom_FIN=0;Hom_NFE=0;Hom_OTH=0;Hom_Male=0;Hom_Female=0;Hom_raw=0;Hom=0;POPMAX=NFE;AC_POPMAX=1;AN_POPMAX=9986;AF_POPMAX=1.00140e-04;DP_MEDIAN=11;DREF_MEDIAN=7.94328e-18;GQ_MEDIAN=99;AB_MEDIAN=5.45455e-01;AS_RF=4.14273e-01;AS_FilterStatus=PASS;CSQ=A|intergenic_variant|MODIFIER||||||||||||||||1||||SNV|1||||||||||||||||||||||||||||||||||||||||||||
+22	16050146	.	A	T	48.32	RF;AC0	AC=0;AF=0.00000e+00;AN=20636;BaseQRankSum=-3.54000e-01;ClippingRankSum=5.50000e-01;DP=264413;FS=2.76200e+00;InbreedingCoeff=-4.10000e-03;MQ=3.73000e+01;MQRankSum=2.00000e+00;QD=6.90000e+00;ReadPosRankSum=2.00000e+00;SOR=1.53600e+00;VQSLOD=-3.42700e+01;VQSR_culprit=MQ;GQ_HIST_ALT=0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|1|0|0|0|0;DP_HIST_ALT=0|1|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALT=0|0|0|0|0|0|0|0|0|0|0|1|0|0|0|0|0|0|0|0;GQ_HIST_ALL=84|258|359|1323|2262|1285|2499|2192|869|1402|937|374|819|84|270|69|176|10|92|126;DP_HIST_ALL=524|4533|5628|2926|1267|363|187|58|4|0|0|0|0|0|0|0|0|0|0|0;AB_HIST_ALL=0|0|0|0|0|0|0|0|0|0|0|1|0|0|0|0|0|0|0|0;AC_AFR=0;AC_AMR=0;AC_ASJ=0;AC_EAS=0;AC_FIN=0;AC_NFE=0;AC_OTH=0;AC_Male=0;AC_Female=0;AN_AFR=5074;AN_AMR=602;AN_ASJ=216;AN_EAS=1154;AN_FIN=2448;AN_NFE=10458;AN_OTH=684;AN_Male=11480;AN_Female=9156;AF_AFR=0.00000e+00;AF_AMR=0.00000e+00;AF_ASJ=0.00000e+00;AF_EAS=0.00000e+00;AF_FIN=0.00000e+00;AF_NFE=0.00000e+00;AF_OTH=0.00000e+00;AF_Male=0.00000e+00;AF_Female=0.00000e+00;GC_AFR=2537,0,0;GC_AMR=301,0,0;GC_ASJ=108,0,0;GC_EAS=577,0,0;GC_FIN=1224,0,0;GC_NFE=5229,0,0;GC_OTH=342,0,0;GC_Male=5740,0,0;GC_Female=4578,0,0;AC_raw=1;AN_raw=30980;AF_raw=3.22789e-05;GC_raw=15489,1,0;GC=10318,0,0;Hom_AFR=0;Hom_AMR=0;Hom_ASJ=0;Hom_EAS=0;Hom_FIN=0;Hom_NFE=0;Hom_OTH=0;Hom_Male=0;Hom_Female=0;Hom_raw=0;Hom=0;POPMAX=.;AC_POPMAX=.;AN_POPMAX=.;AF_POPMAX=.;DP_MEDIAN=7;DREF_MEDIAN=1.00000e-11;GQ_MEDIAN=78;AB_MEDIAN=5.71429e-01;AS_RF=2.11047e-01;AS_FilterStatus=RF|AC0;CSQ=T|intergenic_variant|MODIFIER||||||||||||||||1||||SNV|1||||||||||||||||||||||||||||||||||||||||||||


### PR DESCRIPTION
Removing the assertion seems to enable the functionality without any side effects as far as I can see.

Would appreciate some comments though as I don't fully understand that part of the htslib API.