### PR TITLE
Add a format_options keyword to AlignmentFile

### DIFF
--- a/pysam/libcalignmentfile.pyx
+++ b/pysam/libcalignmentfile.pyx
@@ -717,6 +717,10 @@ cdef class AlignmentFile(HTSFile):
         Issue a warning, instead of raising an error if the current file
         appears to be truncated due to a missing EOF marker.  Only applies
         to bgzipped formats. (Default=False)
+
+    format_options: list
+        A list of key=value strings, as accepted by --input-fmt-option and
+        --output-fmt-option in samtools.
     """
 
     def __cinit__(self, *args, **kwargs):
@@ -787,7 +791,8 @@ cdef class AlignmentFile(HTSFile):
               referencenames=None,
               referencelengths=None,
               duplicate_filehandle=True,
-              ignore_truncation=False):
+              ignore_truncation=False,
+              format_options=None):
         '''open a sam, bam or cram formatted file.
 
         If _open is called on an existing file, the current file
@@ -892,6 +897,8 @@ cdef class AlignmentFile(HTSFile):
                                   force_str(strerror(errno))))
                 else:
                     raise ValueError("could not open alignment file `{}`".format(force_str(filename)))
+            if len(format_options):
+                self.add_hts_options(format_options)
             # set filename with reference sequences. If no filename
             # is given, the CRAM reference arrays will be built from
             # the @SQ header in the header
@@ -918,6 +925,9 @@ cdef class AlignmentFile(HTSFile):
 
             if self.htsfile.format.category != sequence_data:
                 raise ValueError("file does not contain alignment data")
+
+            if len(format_options):
+                self.add_hts_options(format_options)
 
             self.check_truncation(ignore_truncation)
 

--- a/pysam/libcalignmentfile.pyx
+++ b/pysam/libcalignmentfile.pyx
@@ -792,7 +792,7 @@ cdef class AlignmentFile(HTSFile):
               referencelengths=None,
               duplicate_filehandle=True,
               ignore_truncation=False,
-              format_options=None):
+              format_options=[]):
         '''open a sam, bam or cram formatted file.
 
         If _open is called on an existing file, the current file

--- a/pysam/libcalignmentfile.pyx
+++ b/pysam/libcalignmentfile.pyx
@@ -926,7 +926,7 @@ cdef class AlignmentFile(HTSFile):
             if self.htsfile.format.category != sequence_data:
                 raise ValueError("file does not contain alignment data")
 
-            if len(format_options):
+            if format_options and len(format_options):
                 self.add_hts_options(format_options)
 
             self.check_truncation(ignore_truncation)

--- a/pysam/libcalignmentfile.pyx
+++ b/pysam/libcalignmentfile.pyx
@@ -792,7 +792,7 @@ cdef class AlignmentFile(HTSFile):
               referencelengths=None,
               duplicate_filehandle=True,
               ignore_truncation=False,
-              format_options=[]):
+              format_options=None):
         '''open a sam, bam or cram formatted file.
 
         If _open is called on an existing file, the current file
@@ -897,7 +897,7 @@ cdef class AlignmentFile(HTSFile):
                                   force_str(strerror(errno))))
                 else:
                     raise ValueError("could not open alignment file `{}`".format(force_str(filename)))
-            if len(format_options):
+            if format_options and len(format_options):
                 self.add_hts_options(format_options)
             # set filename with reference sequences. If no filename
             # is given, the CRAM reference arrays will be built from

--- a/pysam/libchtslib.pxd
+++ b/pysam/libchtslib.pxd
@@ -424,7 +424,7 @@ cdef extern from "htslib/hts.h" nogil:
         no_compression, gzip, bgzf, custom
         compression_maximum
 
-    enum hts_fmt_option:
+    cdef enum hts_fmt_option:
         CRAM_OPT_DECODE_MD,
         CRAM_OPT_PREFIX,
         CRAM_OPT_VERBOSITY,
@@ -471,6 +471,27 @@ cdef extern from "htslib/hts.h" nogil:
         htsFormat format
 
     int hts_verbose
+
+    cdef union hts_opt_val_union:
+        int i
+        char *s
+
+    ctypedef struct hts_opt:
+        char *arg
+        hts_fmt_option opt
+        hts_opt_val_union val
+        void *next
+
+    # @abstract Parses arg and appends it to the option list.
+    # @return   0 on success and -1 on failure
+    int hts_opt_add(hts_opt **opts, const char *c_arg)
+
+    # @abstract Applies an hts_opt option list to a given htsFile.
+    # @return   0 on success and -1 on failure
+    int hts_opt_apply(htsFile *fp, hts_opt *opts)
+
+    # @abstract Frees an hts_opt list.
+    void hts_opt_free(hts_opt *opts)
 
     # @abstract Table for converting a nucleotide character to 4-bit encoding.
     # The input character may be either an IUPAC ambiguity code, '=' for 0, or

--- a/pysam/libchtslib.pyx
+++ b/pysam/libchtslib.pyx
@@ -571,7 +571,7 @@ cdef class HTSFile(object):
         for format_option in format_options:
             rval = hts_opt_add(&opts, format_option)
             if rval != 0:
-                if opt != NULL:
+                if opts != NULL:
                     hts_opt_free(opts)
                 raise AttributeError('Invalid format option ({}) specified'.format(format_option))
         if opts != NULL:

--- a/pysam/libchtslib.pyx
+++ b/pysam/libchtslib.pyx
@@ -562,6 +562,22 @@ cdef class HTSFile(object):
             with nogil:
                 return hts_hopen(hfile, cfilename, cmode)
 
+    def add_hts_options(self, format_options=[]):
+        """Given a list of key=value format option strings, add them to an open htsFile
+        """
+        cdef int rval
+        cdef hts_opt *opts = NULL
+
+        for format_option in format_options:
+            rval = hts_opt_add(&opts, format_option)
+            if rval != 0:
+                raise AttributeError('Invalid format option ({}) specified'.format(format_option))
+        if opts != NULL:
+            rval = hts_opt_apply(self.htsfile, opts)
+            if rval != 0:
+                raise AttributeError('An error occured while applying the requested format options')
+            hts_opt_free(opts)
+
     def parse_region(self, contig=None, start=None, stop=None, region=None,tid=None,
                      reference=None, end=None):
         """parse alternative ways to specify a genomic region. A region can

--- a/pysam/libchtslib.pyx
+++ b/pysam/libchtslib.pyx
@@ -571,10 +571,13 @@ cdef class HTSFile(object):
         for format_option in format_options:
             rval = hts_opt_add(&opts, format_option)
             if rval != 0:
+                if opt != NULL:
+                    hts_opt_free(opts)
                 raise AttributeError('Invalid format option ({}) specified'.format(format_option))
         if opts != NULL:
             rval = hts_opt_apply(self.htsfile, opts)
             if rval != 0:
+                hts_opt_free(opts)
                 raise AttributeError('An error occured while applying the requested format options')
             hts_opt_free(opts)
 

--- a/pysam/libchtslib.pyx
+++ b/pysam/libchtslib.pyx
@@ -562,24 +562,25 @@ cdef class HTSFile(object):
             with nogil:
                 return hts_hopen(hfile, cfilename, cmode)
 
-    def add_hts_options(self, format_options=[]):
+    def add_hts_options(self, format_options=None):
         """Given a list of key=value format option strings, add them to an open htsFile
         """
         cdef int rval
         cdef hts_opt *opts = NULL
 
-        for format_option in format_options:
-            rval = hts_opt_add(&opts, format_option)
-            if rval != 0:
-                if opts != NULL:
+        if format_options:
+            for format_option in format_options:
+                rval = hts_opt_add(&opts, format_option)
+                if rval != 0:
+                    if opts != NULL:
+                        hts_opt_free(opts)
+                    raise RuntimeError('Invalid format option ({}) specified'.format(format_option))
+            if opts != NULL:
+                rval = hts_opt_apply(self.htsfile, opts)
+                if rval != 0:
                     hts_opt_free(opts)
-                raise AttributeError('Invalid format option ({}) specified'.format(format_option))
-        if opts != NULL:
-            rval = hts_opt_apply(self.htsfile, opts)
-            if rval != 0:
+                    raise RuntimeError('An error occured while applying the requested format options')
                 hts_opt_free(opts)
-                raise AttributeError('An error occured while applying the requested format options')
-            hts_opt_free(opts)
 
     def parse_region(self, contig=None, start=None, stop=None, region=None,tid=None,
                      reference=None, end=None):


### PR DESCRIPTION
This implements #579 and additionally allows decoding specific fields in CRAM files (in the same was as `--input-fmt-option` and `--output-fmt-option` in `samtools view`).

Another possible implementation of this would be to use a `dict()` (I'm not sure what people will find more convenient).

N.B., it's inadvisable to use `required_fields=XXX` and then to attempt to use one of the unrequired fields (try it, you'll get some "interesting" results that I presume are an artefact from htslib).