### PR TITLE
Adding a warning to count_coverage when an alignment has an empty QUAL field

### DIFF
--- a/pysam/libcalignmentfile.pyx
+++ b/pysam/libcalignmentfile.pyx
@@ -1572,7 +1572,7 @@ cdef class AlignmentFile(HTSFile):
                    _start <= refpos < _stop:
 
                     # only check base quality if _threshold > 0
-                    if (_threshold and quality and quality[qpos] > _threshold) or not _threshold:
+                    if (_threshold and quality and quality[qpos] >= _threshold) or not _threshold:
                         if seq[qpos] == 'A':
                             count_a.data.as_ulongs[refpos - _start] += 1
                         if seq[qpos] == 'C':

--- a/pysam/libcalignmentfile.pyx
+++ b/pysam/libcalignmentfile.pyx
@@ -1572,7 +1572,7 @@ cdef class AlignmentFile(HTSFile):
                    _start <= refpos < _stop:
 
                     # only check base quality if _threshold > 0
-                    if (_threshold and quality and quality[qpos] < _threshold) or not _threshold:
+                    if (_threshold and quality and quality[qpos] > _threshold) or not _threshold:
                         if seq[qpos] == 'A':
                             count_a.data.as_ulongs[refpos - _start] += 1
                         if seq[qpos] == 'C':

--- a/pysam/libcalignmentfile.pyx
+++ b/pysam/libcalignmentfile.pyx
@@ -1537,6 +1537,9 @@ cdef class AlignmentFile(HTSFile):
         cdef int refpos
         cdef int c = 0
         cdef int filter_method = 0
+
+        cdef int not_check_qual = 0
+
         if read_callback == "all":
             filter_method = 1
         elif read_callback == "nofilter":
@@ -1564,10 +1567,14 @@ cdef class AlignmentFile(HTSFile):
             # count
             seq = read.seq
             quality = read.query_qualities
+            if not quality:
+                warnings.warn('%s contains QUAL field' %read.query_name)
+                not_check_qual = 1
+
             for qpos, refpos in read.get_aligned_pairs(True):
                 if qpos is not None and refpos is not None and \
                    _start <= refpos < _stop:
-                    if quality[qpos] >= quality_threshold:
+                    if quality[qpos] >= quality_threshold or not_check_qual == 1:
                         if seq[qpos] == 'A':
                             count_a.data.as_ulongs[refpos - _start] += 1
                         if seq[qpos] == 'C':

--- a/pysam/libcalignmentfile.pyx
+++ b/pysam/libcalignmentfile.pyx
@@ -1567,6 +1567,8 @@ cdef class AlignmentFile(HTSFile):
             # count
             seq = read.seq
             quality = read.query_qualities
+            
+            not_check_qual = 0
             if not quality:
                 warnings.warn('%s contains QUAL field' %read.query_name)
                 not_check_qual = 1

--- a/pysam/libcalignmentfile.pyx
+++ b/pysam/libcalignmentfile.pyx
@@ -1538,15 +1538,13 @@ cdef class AlignmentFile(HTSFile):
         cdef int c = 0
         cdef int filter_method = 0
 
-        # check base quality if quality == None or 0
-        cdef int check_qual = 1 if quality_threshold else 0 
 
         if read_callback == "all":
             filter_method = 1
         elif read_callback == "nofilter":
             filter_method = 2
 
-        cdef int _threshold = quality_threshold if quality_threshold else 0
+        cdef int _threshold = quality_threshold or 0
         for read in self.fetch(contig=contig,
                                reference=reference,
                                start=start,
@@ -1569,15 +1567,12 @@ cdef class AlignmentFile(HTSFile):
             seq = read.seq
             quality = read.query_qualities
             
-            if not quality and check_qual == 1:
-                raise ValueError('%s contains no QUAL field, use quality_threshold = None to ignore base quality' %read.query_name)
-
             for qpos, refpos in read.get_aligned_pairs(True):
                 if qpos is not None and refpos is not None and \
                    _start <= refpos < _stop:
 
-                   # only check base quality if check_qual == 1
-                   if check_qual == 0 or quality[qpos] >= quality_threshold:
+                   # only check base quality if _threshold > 0
+                   if _threshold or (not quality or quality[qpos] < _threshold):
                         if seq[qpos] == 'A':
                             count_a.data.as_ulongs[refpos - _start] += 1
                         if seq[qpos] == 'C':

--- a/pysam/libcalignmentfile.pyx
+++ b/pysam/libcalignmentfile.pyx
@@ -1,3 +1,4 @@
+
 # cython: embedsignature=True
 # cython: profile=True
 ########################################################
@@ -1508,7 +1509,6 @@ cdef class AlignmentFile(HTSFile):
 
         """
 
-        
         cdef uint32_t contig_length = self.get_reference_length(contig)
         cdef int _start = start if start is not None else 0
         cdef int _stop = stop if stop is not None else contig_length
@@ -1574,7 +1574,7 @@ cdef class AlignmentFile(HTSFile):
             for qpos, refpos in read.get_aligned_pairs(True):
                 if qpos is not None and refpos is not None and \
                    _start <= refpos < _stop:
-                    if quality[qpos] >= quality_threshold or not_check_qual == 1:
+                    if not_check_qual == 1 or quality[qpos] >= quality_threshold:
                         if seq[qpos] == 'A':
                             count_a.data.as_ulongs[refpos - _start] += 1
                         if seq[qpos] == 'C':
@@ -1583,6 +1583,8 @@ cdef class AlignmentFile(HTSFile):
                             count_g.data.as_ulongs[refpos - _start] += 1
                         if seq[qpos] == 'T':
                             count_t.data.as_ulongs[refpos - _start] += 1
+        if not_check_qual:
+            warnings.warn('All bases were counted')
 
         return count_a, count_c, count_g, count_t
 

--- a/setup.py
+++ b/setup.py
@@ -314,7 +314,7 @@ else:
         "-Wno-unused",
         "-Wno-strict-prototypes",
         "-Wno-sign-compare",
-        ]
+        "-Wno-error=declaration-after-statement"]
 
 define_macros = []
 

--- a/setup.py
+++ b/setup.py
@@ -314,7 +314,7 @@ else:
         "-Wno-unused",
         "-Wno-strict-prototypes",
         "-Wno-sign-compare",
-        "-Wno-error=declaration-after-statement"]
+        ]
 
 define_macros = []
 


### PR DESCRIPTION
Trying to fix issue [#603](https://github.com/pysam-developers/pysam/issues/603). In the ```AlignmentFile.count_coverage()``` method, if an alignment has an empty QUAL field, it raised a ```TypeError```.

I am fixing this by ignoring the quality threshold and counting every bases when an alignment has empty QUAL field. I am adding a warning for these kind of ```AlignedSegment```, so this issue is not silently passed. However, I am not sure if a warning is the best solution or if it should just raise a more clear error?