### PR TITLE
Allow setting number of threads for htslib

### DIFF
--- a/pysam/libcalignmentfile.pyx
+++ b/pysam/libcalignmentfile.pyx
@@ -567,7 +567,7 @@ cdef class AlignmentFile(HTSFile):
     header=None, add_sq_text=False, check_header=True, check_sq=True,
     reference_filename=None, filename=None, index_filename=None,
     filepath_index=None, require_index=False, duplicate_filehandle=True,
-    ignore_truncation=False)
+    ignore_truncation=False, n_threads=1)
 
     A :term:`SAM`/:term:`BAM`/:term:`CRAM` formatted file.
 
@@ -711,6 +711,8 @@ cdef class AlignmentFile(HTSFile):
     format_options: list
         A list of key=value strings, as accepted by --input-fmt-option and
         --output-fmt-option in samtools.
+    n_threads: integer
+        Number of threads to use for compressing/decompressing BAM/CRAM files. (Default=1)
     """
 
     def __cinit__(self, *args, **kwargs):
@@ -782,7 +784,8 @@ cdef class AlignmentFile(HTSFile):
               referencelengths=None,
               duplicate_filehandle=True,
               ignore_truncation=False,
-              format_options=None):
+              format_options=None,
+              n_threads=1):
         '''open a sam, bam or cram formatted file.
 
         If _open is called on an existing file, the current file
@@ -886,6 +889,7 @@ cdef class AlignmentFile(HTSFile):
                                  "header, text or reference_names/reference_lengths")
             
             self.htsfile = self._open_htsfile()
+            hts_set_threads(self.htsfile, n_threads)
 
             if self.htsfile == NULL:
                 if errno:

--- a/tests/AlignmentFile_test.py
+++ b/tests/AlignmentFile_test.py
@@ -1124,6 +1124,32 @@ class TestContextManager(unittest.TestCase):
         self.assertEqual(samfile.closed, True)
 
 
+class TestMultiThread(unittest.TestCase):
+
+    def testSingleThreadEqualsMultithread(self):
+        input_bam = os.path.join(BAM_DATADIR, 'ex1.bam')
+        single_thread_out = get_temp_filename("tmp_single.bam")
+        multi_thread_out = get_temp_filename("tmp_multi.bam")
+        with pysam.AlignmentFile(input_bam,
+                                 'rb') as samfile:
+            reads = [r for r in samfile]
+            with pysam.AlignmentFile(single_thread_out,
+                                     mode='wb',
+                                     template=samfile,
+                                     n_threads=1) as single_out:
+                [single_out.write(r) for r in reads]
+            with pysam.AlignmentFile(multi_thread_out,
+                                     mode='wb',
+                                     template=samfile,
+                                     n_threads=2) as multi_out:
+                [single_out.write(r) for r in reads]
+        with pysam.AlignmentFile(input_bam) as inp, \
+            pysam.AlignmentFile(single_thread_out) as single, \
+            pysam.AlignmentFile(multi_thread_out) as multi:
+            for r1, r2, r3 in zip(inp, single, multi):
+                assert r1.to_string == r2.to_string == r3.to_string
+
+
 class TestExceptions(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Internally this uses hts_set_threads. There is only a minor
speedup for reading files, but writing files can benefit well
from setting n_threads to more than 1:

```
In [1]: def benchmark_write(threads=1):
   ...:     source = pysam.AlignmentFile('/Users/mvandenb/src/readtagger/tests/h4.bam', threads=threads)
   ...:     out = pysam.AlignmentFile('out.bam', mode='wb', template=source, threads=threads)
   ...:     for _ in range(1000000):
   ...:         out.write(next(source))
   ...:

In [2]: %timeit benchmark_write(threads=1)
1 loop, best of 3: 9.21 s per loop

In [3]: %timeit benchmark_write(threads=2)
1 loop, best of 3: 4.68 s per loop

In [4]: %timeit benchmark_write(threads=3)
1 loop, best of 3: 3.17 s per loop

In [5]: %timeit benchmark_write(threads=4)
1 loop, best of 3: 2.66 s per loop
```
This had been discussed in https://github.com/pysam-developers/pysam/issues/579#issuecomment-370766946.