### PR TITLE
Fix operator precedence error by removing premature optimistion

### DIFF
--- a/import.py
+++ b/import.py
@@ -103,7 +103,7 @@ def _update_pysam_files(cf, destdir):
                 lines = re.sub("stdout", "{}_stdout".format(basename), lines)
                 lines = re.sub(" printf\(", " fprintf({}_stdout, ".format(basename), lines)
                 lines = re.sub("([^kf])puts\(([^)]+)\)",
-                               r"\1fputs(\2, {}_stdout) & fputc('\\n', {}_stdout)".format(basename, basename),
+                               r"\1fputs(\2, {}_stdout) != EOF && fputc('\\n', {}_stdout)".format(basename, basename),
                                lines)
                 lines = re.sub("putchar\(([^)]+)\)",
                                r"fputc(\1, {}_stdout)".format(basename), lines)

--- a/samtools/bam.c.pysam.c
+++ b/samtools/bam.c.pysam.c
@@ -51,7 +51,7 @@ int bam_view1(const bam_header_t *header, const bam1_t *b)
     char *s = bam_format1(header, b);
     int ret = -1;
     if (!s) return -1;
-    if (fputs(s, samtools_stdout) & fputc('\n', samtools_stdout) != EOF) ret = 0;
+    if (fputs(s, samtools_stdout) != EOF && fputc('\n', samtools_stdout) != EOF) ret = 0;
     free(s);
     return ret;
 }


### PR DESCRIPTION
!= has higher precedence than & and will be evaluated first.
Replaced with clearer expression.