### PR TITLE
Documentation typo

### DIFF
--- a/pysam/libcalignedsegment.pyx
+++ b/pysam/libcalignedsegment.pyx
@@ -2918,7 +2918,7 @@ cdef class PileupColumn:
 
         mark_matches: bool
 
-          If True, output bases matching the reference as "," or "."
+          If True, output bases matching the reference as "." or ","
           for forward and reverse strand, respectively. This mark
           requires the reference sequence. If no reference is
           present, this option is ignored.


### PR DESCRIPTION
Matching the documentation from samtools mpileup and get_query_sequences() method.