### PR TITLE
Really fix this import.py fputs != EOF && fputc != EOF madness

### DIFF
--- a/devtools/import.py
+++ b/devtools/import.py
@@ -102,9 +102,7 @@ def _update_pysam_files(cf, destdir):
                 lines = re.sub("stderr", "{}_stderr".format(basename), lines)
                 lines = re.sub("stdout", "{}_stdout".format(basename), lines)
                 lines = re.sub(" printf\(", " fprintf({}_stdout, ".format(basename), lines)
-                lines = re.sub("([^kf])puts\(([^)]+)\)",
-                               r"\1fputs(\2, {}_stdout) & fputc('\\n', {}_stdout)".format(basename, basename),
-                               lines)
+                lines = re.sub("([^kf])puts\(", r"\1{}_puts(".format(basename), lines)
                 lines = re.sub("putchar\(([^)]+)\)",
                                r"fputc(\1, {}_stdout)".format(basename), lines)
 

--- a/import/pysam.c
+++ b/import/pysam.c
@@ -54,6 +54,12 @@ void @pysam@_unset_stdout(void)
   @pysam@_stdout_fileno = STDOUT_FILENO;
 }
 
+int @pysam@_puts(const char *s)
+{
+  if (fputs(s, @pysam@_stdout) == EOF) return EOF;
+  return putc('\n', @pysam@_stdout);
+}
+
 void @pysam@_set_optind(int val)
 {
   // setting this in cython via 

--- a/import/pysam.h
+++ b/import/pysam.h
@@ -38,6 +38,8 @@ void @pysam@_unset_stderr(void);
  */
 void @pysam@_unset_stdout(void);
 
+int @pysam@_puts(const char *s);
+
 int @pysam@_dispatch(int argc, char *argv[]);
 
 void @pysam@_set_optind(int);


### PR DESCRIPTION
Rather than trying to rewrite a function call as two function calls when we don't really know what the syntax around the call site looks like, rewrite it as a call to our own function.

I haven't actually run this, but assuming the regexp syntax is right you should get the idea. Needs a followup commit to actually run _import.py_ over the freshly imported source code.