### PR TITLE
Fix EOF issue, part 3

### DIFF
--- a/bcftools/bcftools.pysam.c
+++ b/bcftools/bcftools.pysam.c
@@ -54,6 +54,12 @@ void bcftools_unset_stdout(void)
   bcftools_stdout_fileno = STDOUT_FILENO;
 }
 
+int bcftools_puts(const char *s)
+{
+  if (fputs(s, bcftools_stdout) == EOF) return EOF;
+  return putc('\n', bcftools_stdout);
+}
+
 void bcftools_set_optind(int val)
 {
   // setting this in cython via 

--- a/bcftools/bcftools.pysam.h
+++ b/bcftools/bcftools.pysam.h
@@ -38,6 +38,8 @@ void bcftools_unset_stderr(void);
  */
 void bcftools_unset_stdout(void);
 
+int bcftools_puts(const char *s);
+
 int bcftools_dispatch(int argc, char *argv[]);
 
 void bcftools_set_optind(int);

--- a/bcftools/tabix.c.pysam.c
+++ b/bcftools/tabix.c.pysam.c
@@ -78,7 +78,7 @@ int main_tabix(int argc, char *argv[])
         BGZF *fp;
         s.l = s.m = 0; s.s = 0;
         fp = bgzf_open(argv[optind], "r");
-        while (bgzf_getline(fp, '\n', &s) >= 0) fputs(s.s, bcftools_stdout) & fputc('\n', bcftools_stdout);
+        while (bgzf_getline(fp, '\n', &s) >= 0) bcftools_puts(s.s);
         bgzf_close(fp);
         free(s.s);
     } else if (optind + 2 > argc) { // create index
@@ -122,7 +122,7 @@ int main_tabix(int argc, char *argv[])
         for (i = optind + 1; i < argc; ++i) {
             hts_itr_t *itr;
             if ((itr = tbx_itr_querys(tbx, argv[i])) == 0) continue;
-            while (tbx_bgzf_itr_next(fp, tbx, itr, &s) >= 0) fputs(s.s, bcftools_stdout) & fputc('\n', bcftools_stdout);
+            while (tbx_bgzf_itr_next(fp, tbx, itr, &s) >= 0) bcftools_puts(s.s);
             tbx_itr_destroy(itr);
         }
         free(s.s);

--- a/devtools/import.py
+++ b/devtools/import.py
@@ -102,9 +102,7 @@ def _update_pysam_files(cf, destdir):
                 lines = re.sub("stderr", "{}_stderr".format(basename), lines)
                 lines = re.sub("stdout", "{}_stdout".format(basename), lines)
                 lines = re.sub(" printf\(", " fprintf({}_stdout, ".format(basename), lines)
-                lines = re.sub("([^kf])puts\(([^)]+)\)",
-                               r"\1fputs(\2, {}_stdout) & fputc('\\n', {}_stdout)".format(basename, basename),
-                               lines)
+                lines = re.sub("([^kf])puts\(", r"\1{}_puts(".format(basename), lines)
                 lines = re.sub("putchar\(([^)]+)\)",
                                r"fputc(\1, {}_stdout)".format(basename), lines)
 

--- a/import/pysam.c
+++ b/import/pysam.c
@@ -54,6 +54,12 @@ void @pysam@_unset_stdout(void)
   @pysam@_stdout_fileno = STDOUT_FILENO;
 }
 
+int @pysam@_puts(const char *s)
+{
+  if (fputs(s, @pysam@_stdout) == EOF) return EOF;
+  return putc('\n', @pysam@_stdout);
+}
+
 void @pysam@_set_optind(int val)
 {
   // setting this in cython via 

--- a/import/pysam.h
+++ b/import/pysam.h
@@ -38,6 +38,8 @@ void @pysam@_unset_stderr(void);
  */
 void @pysam@_unset_stdout(void);
 
+int @pysam@_puts(const char *s);
+
 int @pysam@_dispatch(int argc, char *argv[]);
 
 void @pysam@_set_optind(int);

--- a/samtools/bam.c.pysam.c
+++ b/samtools/bam.c.pysam.c
@@ -51,7 +51,7 @@ int bam_view1(const bam_header_t *header, const bam1_t *b)
     char *s = bam_format1(header, b);
     int ret = -1;
     if (!s) return -1;
-    if (fputs(s, samtools_stdout) & fputc('\n', samtools_stdout) != EOF) ret = 0;
+    if (samtools_puts(s) != EOF) ret = 0;
     free(s);
     return ret;
 }

--- a/samtools/bedcov.c.pysam.c
+++ b/samtools/bedcov.c.pysam.c
@@ -173,7 +173,7 @@ int main_bedcov(int argc, char *argv[])
             kputc('\t', &str);
             kputl(cnt[i], &str);
         }
-        fputs(str.s, samtools_stdout) & fputc('\n', samtools_stdout);
+        samtools_puts(str.s);
         bam_mplp_destroy(mplp);
         continue;
 

--- a/samtools/misc/ace2sam.c.pysam.c
+++ b/samtools/misc/ace2sam.c.pysam.c
@@ -164,14 +164,14 @@ int samtools_ace2sam_main(int argc, char *argv[])
             if (dret != '\n') ks_getuntil(ks, '\n', &s, &dret);
             ks_getuntil(ks, '\n', &s, &dret); // skip the empty line
             if (write_cns) {
-                if (t[4].l) fputs(t[4].s, samtools_stdout) & fputc('\n', samtools_stdout);
+                if (t[4].l) samtools_puts(t[4].s);
                 t[4].l = 0;
             }
         } else if (strcmp(s.s, "AF") == 0) { // padded read position
             int reversed, neg, pos;
             if (t[0].l == 0) fatal("come to 'AF' before reading 'CO'");
             if (write_cns) {
-                if (t[4].l) fputs(t[4].s, samtools_stdout) & fputc('\n', samtools_stdout);
+                if (t[4].l) samtools_puts(t[4].s);
                 t[4].l = 0;
             }
             ks_getuntil(ks, 0, &s, &dret); // read name
@@ -244,7 +244,7 @@ int samtools_ace2sam_main(int argc, char *argv[])
             kputs("\t*\t0\t0\t", &t[4]); // empty MRNM, MPOS and TLEN
             kputsn(t[3].s, t[3].l, &t[4]); // unpadded SEQ
             kputs("\t*", &t[4]); // QUAL
-            fputs(t[4].s, samtools_stdout) & fputc('\n', samtools_stdout); // print to samtools_stdout
+            samtools_puts(t[4].s); // print to samtools_stdout
             ++af_i;
         } else if (dret != '\n') ks_getuntil(ks, '\n', &s, &dret);
     }

--- a/samtools/samtools.pysam.c
+++ b/samtools/samtools.pysam.c
@@ -54,6 +54,12 @@ void samtools_unset_stdout(void)
   samtools_stdout_fileno = STDOUT_FILENO;
 }
 
+int samtools_puts(const char *s)
+{
+  if (fputs(s, samtools_stdout) == EOF) return EOF;
+  return putc('\n', samtools_stdout);
+}
+
 void samtools_set_optind(int val)
 {
   // setting this in cython via 

--- a/samtools/samtools.pysam.h
+++ b/samtools/samtools.pysam.h
@@ -38,6 +38,8 @@ void samtools_unset_stderr(void);
  */
 void samtools_unset_stdout(void);
 
+int samtools_puts(const char *s);
+
 int samtools_dispatch(int argc, char *argv[]);
 
 void samtools_set_optind(int);


### PR DESCRIPTION
I re-ran the import scripts using the following commands, starting from the branch in #706:

```
tar -jxvf htslib-1.9.tar.bz2

rm -rf htslib
mv htslib-1.9 htslib
echo '#define HTS_VERSION "1.9"' > htslib/version.h

tar -jxvf samtools-1.9.tar.bz2


rm -rf samtools
python devtools/import.py samtools samtools-1.9/
echo '#define SAMTOOLS_VERSION "1.9"' > samtools/version.h

tar -jxvf bcftools-1.9.tar.bz2

rm -rf bcftools
python devtools/import.py bcftools bcftools-1.9
echo '#define BCFTOOLS_VERSION "1.9"' > bcftools/version.h

# Manually edit pysam/version.py
# Revert a couple of changed files to master
git checkout htslib/htslib.pc.tmp
git checkout bcftools/config.h

# Manually comment out two problematic bam_tview_main lines in samtools/bamtk.c.pysam.c
```