### PR TITLE
pysam_data: cleaning of generated with_md.sam.gz

### DIFF
--- a/tests/pysam_data/Makefile
+++ b/tests/pysam_data/Makefile
@@ -91,6 +91,7 @@ clean:
 	rm -fr *.bam *.bai *.fai *.pileup* *.cram \
 	*~ calDepth *.dSYM pysam_*.sam \
 	ex2.sam ex2.sam.gz ex1.sam \
+	with_md.sam.gz \
 	*.fq.gz
 
 %.fq.gz: %.fq


### PR DESCRIPTION
It is just something one notices when packaging for Debian.