### PR TITLE
Add missing macOS stub files in `MANIFEST.in`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -50,8 +50,8 @@ include htslib/htslib.pc.in
 include htslib/htslib/*.h
 include htslib/cram/*.c
 include htslib/cram/*.h
-include htslib/win/*.c
-include htslib/win/*.h
+include htslib/os/*.c
+include htslib/os/*.h
 include cy_build.py
 include pysam.py
 include requirements.txt


### PR DESCRIPTION
* This caused the PyPI tarballs to miss the stubs
  required for building htslib on macOS. This would
  not show up for source-tree builds, as the files
  are included in git, just not in `MANIFEST.in`.

Fixes #645

@AndreasHeger could you maybe issue a 0.15.1.1 release on PyPI after merging this? Without this, installing pysam is really painful on macOS and requires people to use an ancient version without overlong CIGAR support.