### PR TITLE
Fix bug in get_aligned_pairs

### DIFF
--- a/pysam/libcalignedsegment.pyx
+++ b/pysam/libcalignedsegment.pyx
@@ -1952,6 +1952,8 @@ cdef class AlignedSegment:
                     else:
                         for i from pos <= i < pos + l:
                             result.append((None, i))
+                else:
+                    r_idx += l
                 pos += l
 
             elif op == BAM_CHARD_CLIP:


### PR DESCRIPTION
I  noticed that in pysam 0.15.1, there is a bug with the get_aligned_pairs function when matches_only=True and with_seq=True.  Basically, the read position gets advanced, but the reference position does not.  This fixes that bug, and I believe it won't involve changing any other portions of the code.