### PR TITLE
Update api.rst

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -57,7 +57,10 @@ reads are represented as :class:`~pysam.PileupRead` objects in the
 
     import pysam
     samfile = pysam.AlignmentFile("ex1.bam", "rb" )
-    for pileupcolumn in samfile.pileup("chr1", 100, 120):
+    
+    pileup = bamfile.pileup("chr1", 100, 120)
+
+    for pileupcolumn in pileup:
         print ("\ncoverage at base %s = %s" %
                (pileupcolumn.pos, pileupcolumn.n))
         for pileupread in pileupcolumn.pileups:


### PR DESCRIPTION
When the window is a little bit larger, the original demo may raise error `exit code 139 (interrupted by signal 11: SIGSEGV)`. One assumed reason for this is the garbage collector in python deletes bamfile.pileup (...) while the loop is running and the code goes to empty memory. And to address this problem, the updated demo should be used.
Ref: https://sites.google.com/a/epigenetic.ru/lab-members/kb/it/pysam