### PR TITLE
Add AlignedSegment.compare_sort

### DIFF
--- a/pysam/libcalignedsegment.pxd
+++ b/pysam/libcalignedsegment.pxd
@@ -25,7 +25,7 @@ cdef extern from "htslib_util.h":
     void pysam_set_n_cigar(bam1_t * b, uint32_t v)
     void pysam_update_flag(bam1_t * b, uint16_t v, uint16_t flag)
 
-cdef extern from "samtools/bam_sort.c.pysam.h":
+cdef extern from "bam_sort.c.pysam.h":
     int pysam_cmp_record(bam1_t *a, bam1_t *b, int is_by_qname, const char *sort_by_tag)
 
 

--- a/pysam/libcalignedsegment.pxd
+++ b/pysam/libcalignedsegment.pxd
@@ -25,6 +25,9 @@ cdef extern from "htslib_util.h":
     void pysam_set_n_cigar(bam1_t * b, uint32_t v)
     void pysam_update_flag(bam1_t * b, uint16_t v, uint16_t flag)
 
+cdef extern from "samtools/bam_sort.c.pysam.h":
+    int pysam_cmp_record(bam1_t *a, bam1_t *b, int is_by_qname, const char *sort_by_tag)
+
 
 from pysam.libcalignmentfile cimport AlignmentFile, AlignmentHeader
 ctypedef AlignmentFile AlignmentFile_t

--- a/pysam/libcalignedsegment.pyx
+++ b/pysam/libcalignedsegment.pyx
@@ -1049,7 +1049,7 @@ cdef class AlignedSegment:
 
         If ``tag`` is given it must be a 2 character string, and
         will be used for primary sorting. Ties will be broken
-        using the methdo specified by ``sort_order``.
+        using the method specified by ``sort_order``.
 
         The return value indicates the following:
         -1: This :class:`pysam.AlignedSegment` instance would sort before `other`.

--- a/samtools/bam_sort.c.pysam.c
+++ b/samtools/bam_sort.c.pysam.c
@@ -2438,3 +2438,29 @@ sort_end:
 
     return ret;
 }
+
+// pysam specifc function that compares reads (without forcing an order)
+int pysam_cmp_record(bam1_t *a, bam1_t *b, int is_by_qname, const char *sort_by_tag)
+{
+    struct bam1_tag a_tag;
+    struct bam1_tag b_tag;
+    a_tag.bam_record = a;
+    b_tag.bam_record = b;
+    a_tag.u.tag = NULL;
+    b_tag.u.tag = NULL;
+
+    g_is_by_qname = is_by_qname;
+    if (sort_by_tag) {
+        g_is_by_tag = 1;
+        strncpy(g_sort_tag, sort_by_tag, 2);
+    }
+
+    if (g_is_by_tag) {
+        a_tag.u.tag = bam_aux_get(a, sort_by_tag);
+        b_tag.u.tag = bam_aux_get(b, sort_by_tag);
+        return bam1_cmp_by_tag(a_tag, b_tag);
+
+    } else {
+        return bam1_cmp_core(a_tag, b_tag);
+    }
+}

--- a/samtools/bam_sort.c.pysam.h
+++ b/samtools/bam_sort.c.pysam.h
@@ -1,0 +1,1 @@
+int pysam_cmp_record(bam1_t *a, bam1_t *b, int is_by_qname, const char *sort_by_tag);


### PR DESCRIPTION
This allows users to compare reads via coordinate, queryname or tag
using the samtools rules.
This should be significantly more performant (and easier) than
https://github.com/10XGenomics/supernova/blob/master/tenkit/lib/python/tenkit/bam.py#L975