### PR TITLE
Default to multiple_iterators=False for pileups

### DIFF
--- a/pysam/libcalignmentfile.pyx
+++ b/pysam/libcalignmentfile.pyx
@@ -2611,10 +2611,11 @@ cdef class IteratorColumnRegion(IteratorColumn):
                   int start = 0,
                   int stop = MAX_POS,
                   int truncate = False,
+                  int multiple_iterators = False,
                   **kwargs ):
 
         # initialize iterator
-        self._setup_iterator(tid, start, stop, 1)
+        self._setup_iterator(tid, start, stop, multiple_iterators)
         self.start = start
         self.stop = stop
         self.truncate = truncate


### PR DESCRIPTION
For CRAM files, HTSlib iterators are in fact a stub struct — the real iterator limits are stored within the cram_fd itself, having been set via `cram_set_option(CRAM_OPT_RANGE)`. This means that reopening the CRAM file as a new cram_fd, which happens with `multiple_iterators=True`, is problematic as the iterator limits don't apply to the separate cram_fd.

Avoiding reopening the CRAM file fixes #725.

I was tempted to do something similar in `IteratorColumnAllRefs` but that one works as is (though I don't especially see why!). To be honest, it's not clear what `multiple_iterators=True` is for in general…