### PR TITLE
Fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os:
-  - linx
+  - linux
   - osx
 
 language: c

--- a/devtools/run_tests_travis.sh
+++ b/devtools/run_tests_travis.sh
@@ -38,15 +38,16 @@ conda config --add channels bioconda
 
 # pin versions, so that tests do not fail when pysam/htslib out of step
 # add htslib dependencies
-conda install -y "samtools=1.7" "bcftools=1.6" "htslib=1.7" xz curl bzip2
+conda install -y "samtools=1.9" "bcftools=1.9" "htslib=1.9" xz curl bzip2
 
 # Need to make C compiler and linker use the anaconda includes and libraries:
 export PREFIX=~/miniconda3/
 export CFLAGS="-I${PREFIX}/include -L${PREFIX}/lib"
 export HTSLIB_CONFIGURE_OPTIONS="--disable-libcurl --disable-lzma"
 
+echo "show samtools, htslib, and bcftools versions"
 samtools --version
-htslib --version
+htsfile --version
 bcftools --version
 
 # Try building conda recipe first


### PR DESCRIPTION
Bump the samtools/htslib/bcftools versions used. Pinning 1.7 means Pysam testing is stuck forever at the broken-openssl/libcrypto condapocalypse.

At least, that's a theory on how to get around [these macOS failures](https://api.travis-ci.org/v3/job/512462692/log.txt):

```
dyld: Library not loaded: @rpath/libcrypto.1.0.0.dylib

  Referenced from: /Users/travis/miniconda3/envs/testenv/bin/samtools

  Reason: image not found

./devtools/run_tests_travis.sh: line 48:  2127 Abort trap: 6           samtools --version
```