### PR TITLE
Add py37 to travis matrix, remove 34 and 35

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ language: c
 env:
   matrix:
     - CONDA_PY=2.7
-    - CONDA_PY=3.4
-    - CONDA_PY=3.5
     - CONDA_PY=3.6
+    - CONDA_PY=3.7
   global:
     - PYSAM_LINKING_TEST=1
 

--- a/devtools/run_tests_travis.sh
+++ b/devtools/run_tests_travis.sh
@@ -31,10 +31,9 @@ bash Miniconda3.sh -b
 # activate testenv environment
 source ~/miniconda3/bin/activate testenv
 
-conda config --add channels r
 conda config --add channels defaults
-conda config --add channels conda-forge
 conda config --add channels bioconda
+conda config --add channels conda-forge
 
 # pin versions, so that tests do not fail when pysam/htslib out of step
 # add htslib dependencies


### PR DESCRIPTION
1.  Add py37 to Travis matrix
2.  Remove python 3.4 and 3.5 from Travis matrix, as they are no longer supported on Bioconda and conda-forge
3.  Clean up conda channel setup to match https://bioconda.github.io/