### PR TITLE
More travis fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os:
-  - linx
+  - linux
   - osx
 
 language: c

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ language: c
 env:
   matrix:
     - CONDA_PY=2.7
-    - CONDA_PY=3.4
-    - CONDA_PY=3.5
     - CONDA_PY=3.6
+    - CONDA_PY=3.7
   global:
     - PYSAM_LINKING_TEST=1
 

--- a/devtools/run_tests_travis.sh
+++ b/devtools/run_tests_travis.sh
@@ -37,15 +37,16 @@ conda config --add channels conda-forge
 
 # pin versions, so that tests do not fail when pysam/htslib out of step
 # add htslib dependencies
-conda install -y "samtools=1.7" "bcftools=1.6" "htslib=1.7" xz curl bzip2
+conda install -y "samtools=1.9" "bcftools=1.9" "htslib=1.9" xz curl bzip2
 
 # Need to make C compiler and linker use the anaconda includes and libraries:
 export PREFIX=~/miniconda3/
 export CFLAGS="-I${PREFIX}/include -L${PREFIX}/lib"
 export HTSLIB_CONFIGURE_OPTIONS="--disable-libcurl --disable-lzma"
 
+echo "show samtools, htslib, and bcftools versions"
 samtools --version
-htslib --version
+htsfile --version
 bcftools --version
 
 # Try building conda recipe first

--- a/devtools/run_tests_travis.sh
+++ b/devtools/run_tests_travis.sh
@@ -57,9 +57,6 @@ bcftools --version
 echo "installing via setup.py from repository"
 python setup.py install
 
-# Display version and provenance of all current packages.
-conda list
-
 # create auxilliary data
 echo
 echo 'building test data'

--- a/devtools/run_tests_travis.sh
+++ b/devtools/run_tests_travis.sh
@@ -31,10 +31,9 @@ bash Miniconda3.sh -b
 # activate testenv environment
 source ~/miniconda3/bin/activate testenv
 
-conda config --add channels r
 conda config --add channels defaults
-conda config --add channels conda-forge
 conda config --add channels bioconda
+conda config --add channels conda-forge
 
 # pin versions, so that tests do not fail when pysam/htslib out of step
 # add htslib dependencies

--- a/devtools/run_tests_travis.sh
+++ b/devtools/run_tests_travis.sh
@@ -37,7 +37,8 @@ conda config --add channels conda-forge
 
 # pin versions, so that tests do not fail when pysam/htslib out of step
 # add htslib dependencies
-conda install -y "samtools=1.9" "bcftools=1.9" "htslib=1.9" xz curl bzip2
+# NB: we force usage of conda-forge ncurses to avoid various known issues.  
+conda install -y "samtools=1.9" "bcftools=1.9" "htslib=1.9" xz curl bzip2 conda-forge:ncurses
 
 # Need to make C compiler and linker use the anaconda includes and libraries:
 export PREFIX=~/miniconda3/

--- a/devtools/run_tests_travis.sh
+++ b/devtools/run_tests_travis.sh
@@ -56,6 +56,9 @@ bcftools --version
 echo "installing via setup.py from repository"
 python setup.py install
 
+# Display version and provenance of all current packages.
+conda list
+
 # create auxilliary data
 echo
 echo 'building test data'

--- a/tests/AlignmentFile_test.py
+++ b/tests/AlignmentFile_test.py
@@ -467,7 +467,8 @@ class TestIO(unittest.TestCase):
                        add_sam_header=False)
 
     def testBAM2BAM(self):
-        print(pysam.view("ex2.bam"))
+        fn = os.path.join(BAM_DATADIR, "ex2.bam")
+        print(pysam.view(fn))
         print(pysam.view("tmp_ex2.bam"))
         self.checkEcho("ex2.bam",
                        "ex2.bam",

--- a/tests/AlignmentFile_test.py
+++ b/tests/AlignmentFile_test.py
@@ -467,6 +467,8 @@ class TestIO(unittest.TestCase):
                        add_sam_header=False)
 
     def testBAM2BAM(self):
+        print(pysam.view("ex2.bam"))
+        print(pysam.view("tmp_ex2.bam"))
         self.checkEcho("ex2.bam",
                        "ex2.bam",
                        "tmp_ex2.bam",

--- a/tests/AlignmentFile_test.py
+++ b/tests/AlignmentFile_test.py
@@ -467,9 +467,10 @@ class TestIO(unittest.TestCase):
                        add_sam_header=False)
 
     def testBAM2BAM(self):
-        fn = os.path.join(BAM_DATADIR, "ex2.bam")
-        print(pysam.view(fn))
-        print(pysam.view("tmp_ex2.bam"))
+        f0 = os.path.join(BAM_DATADIR, "ex2.bam")
+        f1 = os.path.join(BAM_DATADIR, "tmp_ex2.bam")
+        print(pysam.view(f0))
+        print(pysam.view(f1))
         self.checkEcho("ex2.bam",
                        "ex2.bam",
                        "tmp_ex2.bam",

--- a/tests/AlignmentFile_test.py
+++ b/tests/AlignmentFile_test.py
@@ -443,7 +443,7 @@ class TestIO(unittest.TestCase):
                 outfile.write(x)
 
             outfile.close()
-
+        print(pysam.view(output_filename))
         self.assertTrue(checkf(
             os.path.join(BAM_DATADIR, reference_filename),
             output_filename),
@@ -468,9 +468,7 @@ class TestIO(unittest.TestCase):
 
     def testBAM2BAM(self):
         f0 = os.path.join(BAM_DATADIR, "ex2.bam")
-        f1 = os.path.join(BAM_DATADIR, "tmp_ex2.bam")
         print(pysam.view(f0))
-        print(pysam.view(f1))
         self.checkEcho("ex2.bam",
                        "ex2.bam",
                        "tmp_ex2.bam",

--- a/tests/AlignmentFile_test.py
+++ b/tests/AlignmentFile_test.py
@@ -443,7 +443,7 @@ class TestIO(unittest.TestCase):
                 outfile.write(x)
 
             outfile.close()
-        print(pysam.view(output_filename))
+
         self.assertTrue(checkf(
             os.path.join(BAM_DATADIR, reference_filename),
             output_filename),
@@ -467,8 +467,6 @@ class TestIO(unittest.TestCase):
                        add_sam_header=False)
 
     def testBAM2BAM(self):
-        f0 = os.path.join(BAM_DATADIR, "ex2.bam")
-        print(pysam.view(f0))
         self.checkEcho("ex2.bam",
                        "ex2.bam",
                        "tmp_ex2.bam",


### PR DESCRIPTION
1.  Add py37 to Travis matrix
2.  Remove python 3.4 and 3.5 from Travis matrix, as they are no longer supported on Bioconda and conda-forge
3.  Clean up conda channel setup to match https://bioconda.github.io/
4.  Fix samtools version used by Travis
5.  Force ncurses to come from `conda-forge` channel to overcome various known issues.


This PR combines #782 and #784.  I wanted to kick off the CI to see if it uncovers anything.  