### PR TITLE
Fix Travis samtools etc versions and BAM comparisons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os:
-  - linx
+  - linux
   - osx
 
 language: c
@@ -7,9 +7,8 @@ language: c
 env:
   matrix:
     - CONDA_PY=2.7
-    - CONDA_PY=3.4
-    - CONDA_PY=3.5
     - CONDA_PY=3.6
+    - CONDA_PY=3.7
   global:
     - PYSAM_LINKING_TEST=1
 

--- a/devtools/import.py
+++ b/devtools/import.py
@@ -94,16 +94,16 @@ def _update_pysam_files(cf, destdir):
                 outfile.write('#include "{}.pysam.h"\n\n'.format(basename))
                 subname, _ = os.path.splitext(os.path.basename(filename))
                 if subname in MAIN.get(basename, []):
-                    lines = re.sub("int main\(", "int {}_main(".format(
+                    lines = re.sub(r"int main\(", "int {}_main(".format(
                         basename), lines)
                 else:
-                    lines = re.sub("int main\(", "int {}_{}_main(".format(
+                    lines = re.sub(r"int main\(", "int {}_{}_main(".format(
                         basename, subname), lines)
                 lines = re.sub("stderr", "{}_stderr".format(basename), lines)
                 lines = re.sub("stdout", "{}_stdout".format(basename), lines)
-                lines = re.sub(" printf\(", " fprintf({}_stdout, ".format(basename), lines)
-                lines = re.sub("([^kf])puts\(", r"\1{}_puts(".format(basename), lines)
-                lines = re.sub("putchar\(([^)]+)\)",
+                lines = re.sub(r" printf\(", " fprintf({}_stdout, ".format(basename), lines)
+                lines = re.sub(r"([^kf])puts\(", r"\1{}_puts(".format(basename), lines)
+                lines = re.sub(r"putchar\(([^)]+)\)",
                                r"fputc(\1, {}_stdout)".format(basename), lines)
 
                 fn = os.path.basename(filename)

--- a/devtools/run_tests_travis.sh
+++ b/devtools/run_tests_travis.sh
@@ -38,15 +38,17 @@ conda config --add channels bioconda
 
 # pin versions, so that tests do not fail when pysam/htslib out of step
 # add htslib dependencies
-conda install -y "samtools=1.7" "bcftools=1.6" "htslib=1.7" xz curl bzip2
+# NB: we force conda-forge:ncurses due to bioconda/bioconda-recipes#13488
+conda install -y "samtools=1.9" "bcftools=1.9" "htslib=1.9" xz curl bzip2 conda-forge:ncurses
 
 # Need to make C compiler and linker use the anaconda includes and libraries:
 export PREFIX=~/miniconda3/
 export CFLAGS="-I${PREFIX}/include -L${PREFIX}/lib"
 export HTSLIB_CONFIGURE_OPTIONS="--disable-libcurl --disable-lzma"
 
+echo "show samtools, htslib, and bcftools versions"
 samtools --version
-htslib --version
+htsfile --version
 bcftools --version
 
 # Try building conda recipe first

--- a/devtools/run_tests_travis.sh
+++ b/devtools/run_tests_travis.sh
@@ -31,10 +31,9 @@ bash Miniconda3.sh -b
 # activate testenv environment
 source ~/miniconda3/bin/activate testenv
 
-conda config --add channels r
 conda config --add channels defaults
-conda config --add channels conda-forge
 conda config --add channels bioconda
+conda config --add channels conda-forge
 
 # pin versions, so that tests do not fail when pysam/htslib out of step
 # add htslib dependencies

--- a/tests/AlignmentFile_test.py
+++ b/tests/AlignmentFile_test.py
@@ -22,7 +22,7 @@ from functools import partial
 
 import pysam
 import pysam.samtools
-from TestUtils import checkBinaryEqual, check_url, \
+from TestUtils import checkBinaryEqual, checkGZBinaryEqual, check_url, \
     check_samtools_view_equal, checkFieldEqual, force_str, \
     get_temp_filename, BAM_DATADIR
 
@@ -470,7 +470,8 @@ class TestIO(unittest.TestCase):
         self.checkEcho("ex2.bam",
                        "ex2.bam",
                        "tmp_ex2.bam",
-                       "rb", "wb")
+                       "rb", "wb",
+                       checkf=checkGZBinaryEqual)
 
     def testCRAM2CRAM(self):
         # in some systems different reference sequence paths might be
@@ -489,7 +490,8 @@ class TestIO(unittest.TestCase):
         self.checkEcho("ex2.sam",
                        "ex2.bam",
                        "tmp_ex2.bam",
-                       "r", "wb")
+                       "r", "wb",
+                       checkf=checkGZBinaryEqual)
 
     def testBAM2SAM(self):
         self.checkEcho("ex2.bam",
@@ -665,7 +667,8 @@ class TestIO(unittest.TestCase):
         self.checkEcho("ex1.bam",
                        "ex1.bam",
                        "tmp_ex1.bam",
-                       "rb", "wb")
+                       "rb", "wb",
+                       checkf=checkGZBinaryEqual)
 
         f = open(os.path.join(BAM_DATADIR, "ex1.bam"))
         samfile = pysam.AlignmentFile(f, "rb")
@@ -1372,7 +1375,7 @@ class TestDeNovoConstruction(unittest.TestCase):
         outfile.close()
 
         self.assertTrue(
-            checkBinaryEqual(tmpfilename, self.bamfile),
+            checkGZBinaryEqual(tmpfilename, self.bamfile),
             "mismatch when construction BAM file, see %s %s" %
             (tmpfilename, self.bamfile))
 

--- a/tests/TestUtils.py
+++ b/tests/TestUtils.py
@@ -96,6 +96,19 @@ def checkBinaryEqual(filename1, filename2):
     return found
 
 
+def checkGZBinaryEqual(filename1, filename2):
+    '''return true if the decompressed contents of the two files
+    are binary equal.
+    '''
+    with gzip.open(filename1, "rb") as infile1:
+        d1 = infile1.read()
+        with gzip.open(filename2, "rb") as infile2:
+            d2 = infile2.read()
+        if d1 == d2:
+            return True
+    return False
+
+
 def check_samtools_view_equal(
         filename1, filename2,
         without_header=False):

--- a/tests/samtools_test.py
+++ b/tests/samtools_test.py
@@ -45,7 +45,7 @@ def get_version(executable):
     if IS_PYTHON3:
         lines = lines.decode('ascii')
     try:
-        x = re.search("Version:\s+(\S+)", lines).groups()[0]
+        x = re.search(r"Version:\s+(\S+)", lines).groups()[0]
     except AttributeError:
         raise ValueError("could not get version from %s" % lines)
     return x
@@ -190,7 +190,7 @@ class SamtoolsTest(unittest.TestCase):
         pysam_method = getattr(self.module, command)
 
         # run samtools
-        full_statement = re.sub("%\(out\)s", self.executable, statement)
+        full_statement = re.sub(r"%\(out\)s", self.executable, statement)
         run_command(" ".join((self.executable, full_statement)))
         # sys.stdout.write("%s %s ok" % (command, self.executable))
 
@@ -200,7 +200,7 @@ class SamtoolsTest(unittest.TestCase):
             parts = parts[:-2]
 
         # avoid interpolation to preserve string quoting, tab chars, etc.
-        pysam_parts = [re.sub("%\(out\)s", "pysam", x) for x in parts[1:]]
+        pysam_parts = [re.sub(r"%\(out\)s", "pysam", x) for x in parts[1:]]
         output = pysam_method(*pysam_parts,
                               raw=True,
                               catch_stdout=True)
@@ -273,7 +273,7 @@ class SamtoolsTest(unittest.TestCase):
             mapped_command = self.get_command(statement, map_to_internal=True)
             pysam_method = getattr(self.module, mapped_command)
             usage_msg = pysam_method.usage()
-            expected = "Usage:\s+{} {}".format(self.executable, command)
+            expected = r"Usage:\s+{} {}".format(self.executable, command)
             self.assertTrue(re.search(expected, usage_msg) is not None)
 
     def tearDown(self):

--- a/tests/tabix_test.py
+++ b/tests/tabix_test.py
@@ -14,7 +14,8 @@ import unittest
 import subprocess
 import glob
 import re
-from TestUtils import check_url, load_and_convert, TABIX_DATADIR, get_temp_filename
+from TestUtils import checkBinaryEqual, checkGZBinaryEqual, check_url, \
+    load_and_convert, TABIX_DATADIR, get_temp_filename
 
 IS_PYTHON3 = sys.version_info[0] >= 3
 
@@ -36,41 +37,6 @@ def myzip_open(infile, mode="r"):
 def splitToBytes(s):
     '''split string and return list of bytes.'''
     return [x.encode("ascii") for x in s.split("\t")]
-
-
-def checkBinaryEqual(filename1, filename2):
-    '''return true if the two files are binary equal.'''
-    if os.path.getsize(filename1) != os.path.getsize(filename2):
-        return False
-
-    with open(filename1, "rb") as infile:
-        d1 = infile.read()
-
-    with open(filename2, "rb") as infile:
-        d2 = infile.read()
-
-    if len(d1) != len(d2):
-        return False
-
-    found = False
-    for c1, c2 in zip(d1, d2):
-        if c1 != c2:
-            break
-    else:
-        found = True
-
-    return found
-
-
-def checkGZBinaryEqual(filename1, filename2):
-    '''return true if the two files are binary equal.'''
-    with gzip.open(filename1, "rb") as infile1:
-        d1 = infile1.read()
-        with gzip.open(filename2, "rb") as infile2:
-            d2 = infile2.read()
-        if d1 == d2:
-            return True
-    return False
 
 
 class TestIndexing(unittest.TestCase):

--- a/tests/tabixproxies_test.py
+++ b/tests/tabixproxies_test.py
@@ -128,7 +128,7 @@ class TestGTF(TestParser):
         """build attribute string from dictionary d"""
         s = "; ".join(["{} \"{}\"".format(x, y) for (x, y) in d.items()]) + ";"
         # remove quotes around numeric values
-        s = re.sub("\"(\d+)\"", r"\1", s)
+        s = re.sub(r'"(\d+)"', r'\1', s)
         return s
 
     def testRead(self):


### PR DESCRIPTION
1. Use `checkGZBinaryEqual` to compare BAM files, as the more recent samtools build likely uses libdeflate rather than zlib — which introduces spurious differences in the compressed streams.

2. Bump the samtools/htslib/bcftools versions used. Pinning 1.7 means Pysam testing is stuck forever at the broken-openssl/libcrypto condapocalypse.

3. Force ncurses to come from conda-forge channel to overcome various known issues.

4. Add py37 to Travis matrix

5. Remove python 3.4 and 3.5 from Travis matrix, as they are no longer supported on Bioconda and conda-forge

6. Clean up conda channel setup to match https://bioconda.github.io/

7. Use raw strings for regular expressions to avoid Python 3.7 "DeprecationWarning: invalid escape sequence".