### PR TITLE
Fix doc of region example in glossary

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -24,7 +24,7 @@ Glossary
       are 0-based, half-open intervals, i.e., the position 10,000 is
       part of the interval, but 20,000 is not. An exception are
       :term:`samtools` compatible region strings such as
-      'chr1:10000:20000', which are closed, i.e., both positions 10,000
+      'chr1:10000-20000', which are closed, i.e., both positions 10,000
       and 20,000 are part of the interval.
 
    column


### PR DESCRIPTION
 samtools compatible region string should be like  ‘chr1:10000-20000’ rather than ‘chr1:10000:20000’. The example is wrong. The code of parse_region (https://github.com/pysam-developers/pysam/blob/9961bebd4cd1f2bf5e42817df25699a6e6344b5a/pysam/libchtslib.pyx#L667) is correct.