### PR TITLE
Remove string buffer size limit in get_query_sequences()

### DIFF
--- a/pysam/libcalignedsegment.pxd
+++ b/pysam/libcalignedsegment.pxd
@@ -70,7 +70,7 @@ cdef class PileupColumn:
     cdef int n_pu
     cdef AlignmentHeader header
     cdef uint32_t min_base_quality
-    cdef uint8_t * buf
+    cdef kstring_t buf
     cdef char * reference_sequence
 
 cdef class PileupRead:

--- a/pysam/libchtslib.pxd
+++ b/pysam/libchtslib.pxd
@@ -20,6 +20,11 @@ cdef extern from "htslib/kstring.h" nogil:
         size_t l, m
         char *s
 
+    int kputc(int c, kstring_t *s)
+    int kputw(int c, kstring_t *s)
+    int kputl(long c, kstring_t *s)
+    int ksprintf(kstring_t *s, const char *fmt, ...)
+
 
 cdef extern from "htslib_util.h" nogil:
     int hts_set_verbosity(int verbosity)


### PR DESCRIPTION
Use HTSlib's `kstring_t`, which reallocates and enlarges its memory as needed, rather than a fixed-size char buffer. Fixes #717.