### PR TITLE
Fix extra quotes in docstrings

### DIFF
--- a/pysam/libcalignmentfile.pyx
+++ b/pysam/libcalignmentfile.pyx
@@ -346,7 +346,7 @@ cdef class AlignmentHeader(object):
         return makeAlignmentHeader(bam_hdr_dup(self.ptr))
 
     property nreferences:
-        """"int with the number of :term:`reference` sequences in the file.
+        """int with the number of :term:`reference` sequences in the file.
 
         This is a read-only attribute."""
         def __get__(self):
@@ -1899,7 +1899,7 @@ cdef class AlignmentFile(HTSFile):
         return self.header.get_reference_length(reference)
     
     property nreferences:
-        """"int with the number of :term:`reference` sequences in the file.
+        """int with the number of :term:`reference` sequences in the file.
         This is a read-only attribute."""
         def __get__(self):
             if self.header:

--- a/pysam/libcfaidx.pyx
+++ b/pysam/libcfaidx.pyx
@@ -214,7 +214,7 @@ cdef class FastaFile:
         return False
 
     property closed:
-        """"bool indicating the current state of the file object.
+        """bool indicating the current state of the file object.
         This is a read-only attribute; the close() method changes the value.
         """
         def __get__(self):
@@ -231,7 +231,7 @@ cdef class FastaFile:
             return self._references
 
     property nreferences:
-        """"int with the number of :term:`reference` sequences in the file.
+        """int with the number of :term:`reference` sequences in the file.
         This is a read-only attribute."""
         def __get__(self):
             return len(self._references) if self.references else None
@@ -610,7 +610,7 @@ cdef class FastxFile:
         return False
 
     property closed:
-        """"bool indicating the current state of the file object.
+        """bool indicating the current state of the file object.
         This is a read-only attribute; the close() method changes the value.
         """
         def __get__(self):


### PR DESCRIPTION
Some docstrings start with 4 quote characters instead of 3 which then shows up as e.g.

> “bool indicating the current state of the file object.

in the [documentation](https://pysam.readthedocs.io/en/latest/api.html#pysam.FastxFile.closed). This PR remove the extra characters.