### PR TITLE
Fix documentation Extending pysam

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -385,7 +385,7 @@ flagstat command and consists of three files:
 2. The cython implementation :file:`_pysam_flagstat.pyx`. This script
    imports the pysam API via::
 
-      from pysam.calignmentfile cimport AlignmentFile, AlignedSegment
+      from pysam.libcalignmentfile cimport AlignmentFile, AlignedSegment
 
    This statement imports, amongst others, :class:`AlignedSegment`
    into the namespace. Speed can be gained from declaring


### PR DESCRIPTION
This pysam.calignmentfile should be pysam.libcalignmentfile.

In version 0.10.0 and onwards, all pysam extension modules contain a lib-prefix. This facilates linking against pysam extension modules with compilers that require to start with lib. As a consequence, all code using pysam extension modules directly will need to be adapted. 
Fount at https://github.com/pysam-developers/pysam/blob/aa27e81b123067427ae08f5345feb891b7efa857/doc/faq.rst#importerror-cannot-import-name-csamtools