### PR TITLE
Fix code block formatting for `tbx.fetch` usage

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -189,7 +189,7 @@ region can be retrieved by calling :meth:`~pysam.TabixFile.fetch()`::
          print (str(row))
 
 This will return a tuple-like data structure in which columns can
-be retrieved by numeric index:
+be retrieved by numeric index::
 
     for row in tbx.fetch("chr1", 1000, 2000):
          print ("chromosome is", row[0])


### PR DESCRIPTION
Tiny fix for the correct formatting of a code block. Turns
<img width="712" alt="Screenshot 2019-06-24 at 19 52 46" src="https://user-images.githubusercontent.com/302566/60044199-c1707680-96b9-11e9-843a-9167d169ec8d.png">
into
<img width="698" alt="Screenshot 2019-06-24 at 19 53 20" src="https://user-images.githubusercontent.com/302566/60044206-c6352a80-96b9-11e9-9b07-3a535f6a15f7.png">
