### PR TITLE
Include AlignmentHeader class in API documention

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -142,6 +142,9 @@ BAM/SAM formatted files.
 .. autoclass:: pysam.AlignmentFile
    :members:
 
+.. autoclass:: pysam.AlignmentHeader
+   :members:
+
 An :class:`~pysam.AlignedSegment` represents an aligned segment within
 a SAM/BAM file.
 


### PR DESCRIPTION
Add class AlignmentHeader to the API documentation.