### PR TITLE
Run configure with the correct CC/CFLAGS/LDFLAGS env vars

### DIFF
--- a/devtools/run_tests_travis.sh
+++ b/devtools/run_tests_travis.sh
@@ -43,7 +43,7 @@ conda install -y "samtools=1.9" "bcftools=1.9" "htslib=1.9" xz curl bzip2 conda-
 # Need to make C compiler and linker use the anaconda includes and libraries:
 export PREFIX=~/miniconda3/
 export CFLAGS="-I${PREFIX}/include -L${PREFIX}/lib"
-export HTSLIB_CONFIGURE_OPTIONS="--disable-libcurl --disable-lzma"
+export HTSLIB_CONFIGURE_OPTIONS="--disable-libcurl"
 
 echo "show samtools, htslib, and bcftools versions"
 samtools --version
@@ -54,8 +54,10 @@ bcftools --version
 ~/miniconda3/bin/conda-build devtools/conda-recipe/ --python=$CONDA_PY
 
 # install code from the repository via setup.py
-echo "installing via setup.py from repository"
-python setup.py install
+echo
+echo "============ installing via setup.py from repository ============"
+echo
+python setup.py install || exit
 
 # create auxilliary data
 echo

--- a/htslib/configure
+++ b/htslib/configure
@@ -4751,12 +4751,7 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_deflate_libdeflate_deflate_compress" >&5
 $as_echo "$ac_cv_lib_deflate_libdeflate_deflate_compress" >&6; }
 if test "x$ac_cv_lib_deflate_libdeflate_deflate_compress" = xyes; then :
-  cat >>confdefs.h <<_ACEOF
-#define HAVE_LIBDEFLATE 1
-_ACEOF
-
-  LIBS="-ldeflate $LIBS"
-
+  :
 else
   libdeflate='missing library'
 fi
@@ -4765,6 +4760,7 @@ fi
 
 $as_echo "#define HAVE_LIBDEFLATE 1" >>confdefs.h
 
+     LIBS="-ldeflate $LIBS"
      private_LIBS="$private_LIBS -ldeflate"
      static_LIBS="$static_LIBS -ldeflate"
 else

--- a/htslib/configure.ac
+++ b/htslib/configure.ac
@@ -275,9 +275,10 @@ fi
 AS_IF([test "x$with_libdeflate" != "xno"],
   [libdeflate=ok
    AC_CHECK_HEADER([libdeflate.h],[],[libdeflate='missing header'],[;])
-   AC_CHECK_LIB([deflate], [libdeflate_deflate_compress],[],[libdeflate='missing library'])
+   AC_CHECK_LIB([deflate], [libdeflate_deflate_compress],[:],[libdeflate='missing library'])
    AS_IF([test "$libdeflate" = "ok"],
     [AC_DEFINE([HAVE_LIBDEFLATE], 1, [Define if libdeflate is available.])
+     LIBS="-ldeflate $LIBS"
      private_LIBS="$private_LIBS -ldeflate"
      static_LIBS="$static_LIBS -ldeflate"],
     [AS_IF([test "x$with_libdeflate" != "xcheck"],


### PR DESCRIPTION
Prevent build failures by ensuring that `configure` uses the same compiler and CFLAGS/etc that will be used later when the Cython and C source itself is compiled.

In particular, the sysconfig $CFLAGS (oddly enough) prevents the compiler from searching /usr/local/include (at least on macOS). Without this PR, configure sees (Homebrew/etc's) /usr/local/include/lzma.h so defines `HAVE_LZMA_H`; later when compiling htslib/cram/cram_io.c that directory is not searched, leading to `<lzma.h> not found` errors. Ensuring that configure also does not see lzma.h there leaves `HAVE_LZMA_H` undefined, which activates HTSlib's os/lzma_stub.h workaround for this header being missing and leads to an lzma-enabled pysam using macOS's system liblzma.dylib.

Fixes #495. Fixes #828.

[It appears I didn't submit this PR back in May, likely because there was no response to my other PRs at the time.]