### PR TITLE
Fix silent truncation of FASTQ with bad q strings

### DIFF
--- a/pysam/libcfaidx.pyx
+++ b/pysam/libcfaidx.pyx
@@ -646,8 +646,14 @@ cdef class FastxFile:
             if self.persist:
                 return FastxRecord(proxy=makeFastqProxy(self.entry))
             return makeFastqProxy(self.entry)
-        else:
+        elif (l == -1):
             raise StopIteration
+        elif (l == -2):
+            raise ValueError('truncated quality string in {0}'
+                             .format(self._filename))
+        else:
+            raise ValueError('unknown problem parsing {0}'
+                             .format(self._filename))
 
 # Compatibility Layer for pysam 0.8.1
 cdef class FastqFile(FastxFile):


### PR DESCRIPTION
Prior to this commit, `pysam` silently truncates FASTQ files that have bad quality strings. For instance, consider the following code which attempts to read a FASTQ file where the quality string is invalid because it differs in length from the sequence:

    import tempfile
    import pysam

    with tempfile.NamedTemporaryFile('wt') as f:
        f.write('>name\nACT\n+\n????')
        f.flush()
        nreads = len([r for r in pysam.FastxFile(f.name)])
        print(nreads)

Prior to this commit, the above code would return 0 even though there is in fact 1 invalid entry in the FASTQ. The reason is that in the code, `kseq_read` returns -1 for end of file but -2 for truncated quality string, but the code for `FastxFile` assumes end of file for any return < 0.

With this commit, an error is now raised for invalid FASTQ files rather than silently truncating the file.