### PR TITLE
Attempt to fix of #799.

### DIFF
--- a/pysam/libcbcf.pyx
+++ b/pysam/libcbcf.pyx
@@ -4080,6 +4080,7 @@ cdef class VariantFile(HTSFile):
 
     def __next__(self):
         cdef int ret
+        cdef int errcode
         cdef bcf1_t *record = bcf_init1()
 
         if not record:
@@ -4093,7 +4094,10 @@ cdef class VariantFile(HTSFile):
             ret = bcf_read1(self.htsfile, self.header.ptr, record)
 
         if ret < 0:
+            errcode = record.errcode
             bcf_destroy1(record)
+            if errcode:
+                raise IOError('unable to parse next record')
             if ret == -1:
                 raise StopIteration
             elif ret == -2:


### PR DESCRIPTION
Due to identical return code of `-1` for cases where the end of the file is reached (non-error case) from cases where an error during parsing occurred (e.g. due to incorrect type of field), it is now reading out the error code that may be set inside the `bcf1_t*` record.

In this way, `pysam` can raise an exception and the user is able to properly handle it instead of having a putatively successful read and the burden to check the stderr for any messages like `[E::vcf_parse_format]` or to check whether the total number of records has been processed.