### PR TITLE
Prevent segfault on Python 2.7 AlignedSegment.compare(other=None)

### DIFF
--- a/pysam/libcalignedsegment.pyx
+++ b/pysam/libcalignedsegment.pyx
@@ -999,6 +999,10 @@ cdef class AlignedSegment:
         <,=,> to *other*
         '''
 
+        # avoid segfault when other equals None
+        if other is None:
+            return -1
+
         cdef int retval, x
         cdef bam1_t *t
         cdef bam1_t *o

--- a/tests/AlignedSegment_test.py
+++ b/tests/AlignedSegment_test.py
@@ -82,7 +82,7 @@ class TestAlignedSegment(ReadTest):
 
         self.assertFalse(a is b)
         self.assertFalse(a == b)
-        self.assertFalse(a.compare(b))
+        self.assertEqual(-1, a.compare(b))
 
         b = self.build_read()
 

--- a/tests/AlignedSegment_test.py
+++ b/tests/AlignedSegment_test.py
@@ -78,6 +78,12 @@ class TestAlignedSegment(ReadTest):
     def testCompare(self):
         '''check comparison functions.'''
         a = self.build_read()
+        b = None
+
+        self.assertFalse(a is b)
+        self.assertFalse(a == b)
+        self.assertFalse(a.compare(b))
+
         b = self.build_read()
 
         self.assertEqual(0, a.compare(b))


### PR DESCRIPTION
Comparing an `AlignedSegment` object to `None` throws a Segmentation Fault, when running on Python 2.7.  Using Python 3 did not yield the segfault in a one-off test.

The specific condition to throw the segfault is when testing object equality.  Instance equality seems to work fine.
```
a = pysam.AlignedSegment()
b = None

a is b   # False
a == b # segfault
a.compare(b) # segfault
```

The submitted PR includes additions to the unit tests to reproduce the segfault, as well as the fix.  The current workaround is for users to use the `is` operator when `None` is a potential comparison argument.



As stated before, this issue was reliably reproduced on the following, using Python 2.7.

**Docker images**
- `python:2.7.17-slim-buster`
- `python:2.7.17-alpine`
- `centos:7.5.1804`

**Bare Metal & KVM**
- CentOS 7

In the case of CentOS 7, I tried installing with pip, conda, and building from source.  None of these approaches seemed to resolve the issue.  I was unable to reproduce the bug on the `python:3.7.5-slim-buster` Docker image, so I assume that somehow Python 3 is safe.