### PR TITLE
Fix incorrect quoting in VariantFile contig records

### DIFF
--- a/pysam/utils.py
+++ b/pysam/utils.py
@@ -102,3 +102,10 @@ class PysamDispatcher(object):
             return stderr
         else:
             return stdout
+
+
+class unquoted_str(str):
+    '''Tag a value as an unquoted string. Meta-information in the VCF
+    header takes the form of key=value pairs. By default, pysam will
+    enclose the value in quotation marks. Tagging that value with
+    unquoted_str will prevent this quoting.'''


### PR DESCRIPTION
Fixes #909. This pull request addresses the quoting issue when adding contigs to a VariantFile's header. In addition, I implemented a more generic solution that disables quoting of attribute values by tagging those values with `unquoted_str`. This may be helpful for addressing similar issues with other types of meta-information.