### PR TITLE
Implement pileup() for unindexed files and/or SAM files

### DIFF
--- a/pysam/libcalignmentfile.pxd
+++ b/pysam/libcalignmentfile.pxd
@@ -140,6 +140,7 @@ cdef class IteratorColumn:
                          int start,
 			 int stop,
  			 int multiple_iterators=?)
+    cdef _setup_raw_rest_iterator(self)
 
     cdef reset(self, tid, start, stop)
     cdef _free_pileup_iter(self)
@@ -154,6 +155,10 @@ cdef class IteratorColumnRegion(IteratorColumn):
 
 
 cdef class IteratorColumnAllRefs(IteratorColumn):
+    pass
+
+
+cdef class IteratorColumnAll(IteratorColumn):
     pass
 
 


### PR DESCRIPTION
Reorganise `pileup` so that it chooses between `IteratorColumnRegion`/ `IteratorColumnAllRefs`/ `IteratorColumnAll` primarily by `has_coord` (i.e., whether `contig`+etc/`region` was specified) and secondarily by `has_index`.

Add `IteratorColumnAll()` which iterates as per HTS_IDX_REST, piling up the entire file, which works without an index and for SAM files. (Unfortunately `sam_itr_next()` does not work for SAM files (even for HTS_IDX_REST) prior to HTSlib 1.10. Instead we follow `samtools mpileup`'s
lead and special case this to use `sam_read1()` at the bottom level instead of `sam_itr_next()`.)

The common parts of the two `_setup_iterator` functions could in future be refactored…