### PR TITLE
{AH} bump version to 0.16.0

### DIFF
--- a/doc/release.rst
+++ b/doc/release.rst
@@ -6,11 +6,24 @@ Release 0.16.0
 ==============
 
 This release wraps htslib/bcftools version 1.10.2 and samtools version
-1.10. Additional bugfixes:
+1.10. The following bugs reported against pysam are fixed due to this:
 
-* [#909] Fix incorrect quoting in VariantFile contig records
-* [#916] Implement pileup() for unindexed files and/or SAM files
+* [#447] Writing out QNAME longer than 251 characters corrupts BAM
+* [#640, #734, #843] Setting VariantRecord pos or stop raises error
+* [#738, #919] FastxFile truncates concatenated plain gzip compressed files
+
+Additional bugfixes:
+
+* [#840] Pileup doesn't work on python3 when `index_filename` is used
 * [#886] FastqProxy raises ValueError when instantiated from python
+* [#904] VariantFile.fetch() throws ValueError on files with no records
+* [#909] Fix incorrect quoting in VariantFile contig records
+* [#915, #916] Implement pileup() for unindexed files and/or SAM files
+
+Backwards incompatible changes:
+
+* The `samtools import` command was removed in samtools 1.10, so pysam
+  no longer exports a `samimport` function. Use `pysam.view()` instead.
 
 
 Release 0.15.4

--- a/doc/release.rst
+++ b/doc/release.rst
@@ -2,6 +2,17 @@
 Release notes
 =============
 
+Release 0.16.0
+==============
+
+This release wraps htslib/bcftools version 1.10.2 and samtools version
+1.10. Additional bugfixes:
+
+* [#909] Fix incorrect quoting in VariantFile contig records
+* [#916] Implement pileup() for unindexed files and/or SAM files
+* [#886] FastqProxy raises ValueError when instantiated from python
+
+
 Release 0.15.4
 ==============
 

--- a/pysam/version.py
+++ b/pysam/version.py
@@ -1,5 +1,5 @@
 # pysam versioning information
-__version__ = "0.15.4"
+__version__ = "0.16.0"
 
 __samtools_version__ = "1.10"
 __bcftools_version__ = "1.10.2"


### PR DESCRIPTION
Release candidate for v0.16.0 release - apologies for the delay.

Hi @bioinformed  and @jmarshall , is there anything you think I should wait for?

Otherwise I will update the docs and push out the release.

