### PR TITLE
Fixed "idx_test_and_fetch" to return proper index filename string length

### DIFF
--- a/htslib/hts.c
+++ b/htslib/hts.c
@@ -3395,6 +3395,7 @@ static int idx_test_and_fetch(const char *fn, const char **local_fn, int *local_
             fclose(local_fp);
             free(s.s);
             *local_fn = p;
+            *local_len = e-p;
             return 0;
         }
 


### PR DESCRIPTION
This change makes the hts.c consistent with the official htslib codebase and fixes a bug where the locally downloaded index could not be found when accessing remote tabix files.