### PR TITLE
adding a new line character at the example of pysam.FastxFile to write a valid fastx file

### DIFF
--- a/pysam/libcfaidx.pyx
+++ b/pysam/libcfaidx.pyx
@@ -541,7 +541,7 @@ cdef class FastxFile:
     ...        print(entry.quality)
     >>> with pysam.FastxFile(filename) as fin, open(out_filename, mode='w') as fout:
     ...    for entry in fin:
-    ...        fout.write(str(entry))
+    ...        fout.write(''.join([str(entry),'\n']))
 
     """
     def __cinit__(self, *args, **kwargs):


### PR DESCRIPTION
otherwise quality line would be mixed up with the header line