### PR TITLE
[WIP] build pysam on Windows

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,8 @@ addopts = -s -v
 testpaths = pysam tests
 pep8maxlinelength = 120
 pep8ignore = E402
+
+[build]
+compiler=mingw32
+[build_ext]
+compiler=mingw32

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ import re
 import subprocess
 import sys
 import sysconfig
+import distutils
 from contextlib import contextmanager
 from setuptools import setup
 from cy_build import CyExtension as Extension, cy_build_ext as build_ext
@@ -54,7 +55,7 @@ def run_configure(option):
     sys.stdout.flush()
     try:
         retcode = subprocess.call(
-            " ".join(("./configure", option)),
+            " ".join(("sh ./configure", option)),
             shell=True)
         if retcode != 0:
             return False
@@ -242,7 +243,7 @@ if HTSLIB_MODE in ['shared', 'separate']:
     for key, value in htslib_make_options.items():
         print ("# pysam: htslib_config {}={}".format(key, value))
 
-    external_htslib_libraries = ['z']
+    external_htslib_libraries = ['z', 'regex', 'tre', 'intl', 'iconv']
     if "LIBS" in htslib_make_options:
         external_htslib_libraries.extend(
             [re.sub("^-l", "", x) for x in htslib_make_options["LIBS"].split(" ") if x.strip()])
@@ -319,7 +320,7 @@ for fn in config_headers:
 
 #######################################################
 # Windows compatibility - untested
-if platform.system() == 'Windows':
+if False:
     include_os = ['win32']
     os_c_files = ['win32/getopt.c']
     extra_compile_args = []
@@ -338,20 +339,27 @@ else:
 
 define_macros = []
 
-suffix = sysconfig.get_config_var('EXT_SUFFIX')
+suffix = distutils.sysconfig.get_config_var('EXT_SUFFIX')
 if not suffix:
-    suffix = sysconfig.get_config_var('SO')
+    suffix = distutils.sysconfig.get_config_var('SO')
 
 internal_htslib_libraries = [
-    os.path.splitext("chtslib{}".format(suffix))[0]]
+    ":libchtslib{}".format(suffix)]
 internal_samtools_libraries = [
-    os.path.splitext("csamtools{}".format(suffix))[0],
-    os.path.splitext("cbcftools{}".format(suffix))[0],
+    ":libcsamtools{}".format(suffix),
+    ":libcbcftools{}".format(suffix),
     ]
 internal_pysamutil_libraries = [
-    os.path.splitext("cutils{}".format(suffix))[0]]
+    ":libcutils{}".format(suffix)]
 
-libraries_for_pysam_module = external_htslib_libraries + internal_htslib_libraries + internal_pysamutil_libraries
+external_htslib_objects = []
+for lib in external_htslib_libraries:
+    if lib != "ws2_32":
+        external_htslib_objects.append("C:/msys64/mingw64/lib/lib{}.a".format(lib))
+
+internal_htslib_libraries.append("ws2_32")
+
+libraries_for_pysam_module = internal_htslib_libraries + internal_pysamutil_libraries
 
 # Order of modules matters in order to make sure that dependencies are resolved.
 # The structures of dependencies is as follows:
@@ -367,17 +375,19 @@ libraries_for_pysam_module = external_htslib_libraries + internal_htslib_librari
 modules = [
     dict(name="pysam.libchtslib",
          sources=[source_pattern % "htslib", "pysam/htslib_util.c"] + shared_htslib_sources + os_c_files,
-         libraries=external_htslib_libraries),
+         extra_link_args=["-Wl,--export-all-symbols"]),
     dict(name="pysam.libcsamtools",
          sources=[source_pattern % "samtools"] + glob.glob(os.path.join("samtools", "*.pysam.c")) +
          [os.path.join("samtools", "lz4", "lz4.c")] + htslib_sources + os_c_files,
-         libraries=external_htslib_libraries + internal_htslib_libraries),
+         libraries=internal_htslib_libraries,
+         extra_link_args=["-Wl,--export-all-symbols"]),
     dict(name="pysam.libcbcftools",
          sources=[source_pattern % "bcftools"] + glob.glob(os.path.join("bcftools", "*.pysam.c")) + htslib_sources + os_c_files,
-         libraries=external_htslib_libraries + internal_htslib_libraries),
+         libraries=internal_htslib_libraries,
+         extra_link_args=["-Wl,--export-all-symbols"]),
     dict(name="pysam.libcutils",
          sources=[source_pattern % "utils", "pysam/pysam_util.c"] + htslib_sources + os_c_files,
-         libraries=external_htslib_libraries + internal_htslib_libraries + internal_samtools_libraries),
+         libraries=internal_htslib_libraries + internal_samtools_libraries),
     dict(name="pysam.libcalignmentfile",
          sources=[source_pattern % "alignmentfile"] + htslib_sources + os_c_files,
          libraries=libraries_for_pysam_module),
@@ -413,6 +423,7 @@ common_options = dict(
     define_macros=define_macros,
     # for out-of-tree compilation, use absolute paths
     library_dirs=[os.path.abspath(x) for x in ["pysam"] + htslib_library_dirs],
+    extra_objects=external_htslib_objects,
     include_dirs=[os.path.abspath(x) for x in htslib_include_dirs + \
                   ["samtools", "samtools/lz4", "bcftools", "pysam", "."] + include_os])
 


### PR DESCRIPTION
dirty fix, need improvement.

The attachment wheel can be installed to Anaconda3 2020.02 without other dependencies.

[pysam-0.16.0.1-cp37-cp37m-win_amd64.whl.zip](https://github.com/pysam-developers/pysam/files/5480382/pysam-0.16.0.1-cp37-cp37m-win_amd64.whl.zip)

### How to build the wheel with this fix:

Windows 10 (assume that the username is User)
Visual Studio 2019 16.7 (with C++ development installed)
Anaconda3 2020.02 (assume that the install path is `C:\Users\User\anaconda3`)
MSYS2 x86_64 20200903 (assume that the install path is `C:\msys64`)

- edit `C:\Users\User\anaconda3\Lib\distutils\cygwinccompiler.py` Line 87

``` python
        elif int(msc_ver) >= 1900:
            # VS2015 / MSVC 14.0
            return ['msvcr140']
```
to
``` python
        elif int(msc_ver) >= 1900:
            # VS2015 / MSVC 14.0
            return ['vcruntime140']
```

- Open Start > MSYS2 64bit > MSYS2 MSYS
execute `pacman -S --needed --noconfirm libraries mingw-w64-x86_64-toolchain`

- copy `C:\msys64\mingw64\bin\mingw32-make.exe` to `C:\msys64\mingw64\bin\make.exe`

- Open Start > MSYS2 64bit > MSYS2 MinGW 64-bit
``` bash
export LIBRARY_PATH=/c/Users/User/anaconda3

export PATH=/c/Users/User/anaconda3:\
/c/Users/User/anaconda3/Library/mingw-w64/bin:\
/c/Users/User/anaconda3/Library/usr/bin:\
/c/Users/User/anaconda3/Library/bin:\
/c/Users/User/anaconda3/Scripts:$PATH

cd pysam
python setup.py bdist_wheel

```