### PR TITLE
docs: fix simple typo, requring -> requiring

### DIFF
--- a/htslib/cram/mFILE.c
+++ b/htslib/cram/mFILE.c
@@ -258,7 +258,7 @@ mFILE *mfcreate_from(const char *path, const char *mode_str, FILE *fp) {
 
 /*
  * Converts a FILE * to an mFILE *.
- * Use this for wrapper functions to turn external prototypes requring
+ * Use this for wrapper functions to turn external prototypes requiring
  * FILE * as an argument into internal code using mFILE *.
  */
 mFILE *mfreopen(const char *path, const char *mode_str, FILE *fp) {


### PR DESCRIPTION
There is a small typo in htslib/cram/mFILE.c.

Should read `requiring` rather than `requring`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md