### PR TITLE
Finishes commenting libctabixproxies

### DIFF
--- a/pysam/__init__.py
+++ b/pysam/__init__.py
@@ -40,7 +40,6 @@ __all__ = \
     libcbcf.__all__ +\
     libcbgzf.__all__ +\
     libcfaidx.__all__ +\
-    libctabixproxies.__all__ +\
     libcalignmentfile.__all__ +\
     libcalignedsegment.__all__ +\
     libcsamfile.__all__ +\
@@ -87,7 +86,7 @@ def get_libraries():
     # Note that this list does not include libcsamtools.so as there are
     # numerous name conflicts with libchtslib.so.
     dirname = os.path.abspath(os.path.join(os.path.dirname(__file__)))
-    pysam_libs = ['libctabixproxies',
+    pysam_libs = [
                   'libcfaidx',
                   'libcsamfile',
                   'libcvcf',


### PR DESCRIPTION
I am having issues when running under Python-3.9 installed on MacOS Big Sur using homebrew.  I believe this is related to the issue  pysam-developers/pysam#443 . I patched this on my local computer by removing the mentions to libctabixproxies in the __init__.py that remain.

The error I was getting was the following: 

```
  File "/usr/local/lib/python3.9/site-packages/pysam/__init__.py", line 43, in <module>
    libctabixproxies.__all__ +\
NameError: name 'libctabixproxies' is not defined
``` 