### PR TITLE
Add support for pathlib.Path as filename arguments 

### DIFF
--- a/pysam/libcutils.pyx
+++ b/pysam/libcutils.pyx
@@ -6,7 +6,11 @@ import tempfile
 import os
 import io
 from contextlib import contextmanager
-from pathlib import Path
+try:
+    from pathlib import Path
+except:
+    # for Python 2
+    Path = str
 
 from cpython.version cimport PY_MAJOR_VERSION, PY_MINOR_VERSION
 from cpython cimport PyBytes_Check, PyUnicode_Check

--- a/pysam/libcutils.pyx
+++ b/pysam/libcutils.pyx
@@ -6,6 +6,7 @@ import tempfile
 import os
 import io
 from contextlib import contextmanager
+from pathlib import Path
 
 from cpython.version cimport PY_MAJOR_VERSION, PY_MINOR_VERSION
 from cpython cimport PyBytes_Check, PyUnicode_Check
@@ -102,6 +103,8 @@ cdef str TEXT_ENCODING = 'utf-8'
 
 cdef bytes encode_filename(object filename):
     """Make sure a filename is 8-bit encoded (or None)."""
+    if isinstance(filename, Path):
+        filename = str(filename)
     if filename is None:
         return None
     elif PY_MAJOR_VERSION >= 3 and PY_MINOR_VERSION >= 2:


### PR DESCRIPTION
Context: 
- python 3 has two ways to pass paths: str/bytes and pathlib.Path (very convenient BTW)
- most functions and libs (e.g. open, pandas) handle pathlib.Path very well, and can use for filenames instead of `str`s. However that doesn't work for e.g. pysam.AlignmentFile and I keep forgetting this. This small change fixes the problem.