### PR TITLE
Missing backtick

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -141,7 +141,7 @@ I can't call AlignmentFile.fetch on a file without index
 
 :meth:`~pysam.AlignmentFile.fetch` requires an index when
 iterating over a SAM/BAM file. To iterate over a file without
-index, use the ``until_eof=True`::
+index, use the ``until_eof=True``::
 
     bf = pysam.AlignmentFile(fname, "rb")
     for r in bf.fetch(until_eof=True):


### PR DESCRIPTION
Missing 1 backtick, which means the existing backticks appear in the documentation instead of showing the snippet as code.