### PR TITLE
Add get/set_encoding_error_handler() to control UTF-8 conversion

### DIFF
--- a/pysam/libcbcf.pyx
+++ b/pysam/libcbcf.pyx
@@ -302,7 +302,7 @@ cdef bcf_array_to_object(void *data, int type, ssize_t n, ssize_t count, int sca
             else:
                 # Otherwise, copy the entire block
                 b = datac[:n]
-            value = tuple(v.decode('utf-8') if v and v != bcf_str_missing else None for v in b.split(b','))
+            value = tuple(force_str(v) if v and v != bcf_str_missing else None for v in b.split(b','))
     else:
         value = []
         if type == BCF_BT_INT8:

--- a/pysam/libcbcf.pyx
+++ b/pysam/libcbcf.pyx
@@ -143,7 +143,7 @@ cdef tuple METADATA_LENGTHS = ('FIXED', 'VARIABLE', 'A', 'G', 'R')
 ########################################################################
 
 from pysam.libcutils cimport force_bytes, force_str, charptr_to_str, charptr_to_str_w_len
-from pysam.libcutils cimport encode_filename, from_string_and_size
+from pysam.libcutils cimport encode_filename, from_string_and_size, decode_bytes
 
 
 ########################################################################
@@ -302,7 +302,7 @@ cdef bcf_array_to_object(void *data, int type, ssize_t n, ssize_t count, int sca
             else:
                 # Otherwise, copy the entire block
                 b = datac[:n]
-            value = tuple(force_str(v) if v and v != bcf_str_missing else None for v in b.split(b','))
+            value = tuple(decode_bytes(v, 'utf-8') if v and v != bcf_str_missing else None for v in b.split(b','))
     else:
         value = []
         if type == BCF_BT_INT8:

--- a/pysam/libcutils.pxd
+++ b/pysam/libcutils.pxd
@@ -23,11 +23,12 @@ cpdef set_encoding_error_handler(name)
 ########################################################################
 ## Python 3 compatibility functions
 ########################################################################
-cdef charptr_to_str(const char *s, encoding=*)
-cdef bytes charptr_to_bytes(const char *s, encoding=*)
-cdef charptr_to_str_w_len(const char* s, size_t n, encoding=*)
-cdef force_str(object s, encoding=*)
-cdef bytes force_bytes(object s, encoding=*)
+cdef charptr_to_str(const char *s, encoding=*, errors=*)
+cdef bytes charptr_to_bytes(const char *s, encoding=*, errors=*)
+cdef charptr_to_str_w_len(const char* s, size_t n, encoding=*, errors=*)
+cdef force_str(object s, encoding=*, errors=*)
+cdef bytes force_bytes(object s, encoding=*, errors=*)
+cdef decode_bytes(bytes s, encoding=*, errors=*)
 cdef bytes encode_filename(object filename)
 cdef from_string_and_size(const char *s, size_t length)
 

--- a/pysam/libcutils.pxd
+++ b/pysam/libcutils.pxd
@@ -14,7 +14,12 @@ cpdef array_to_qualitystring(c_array.array arr, int offset=*)
 cpdef qualities_to_qualitystring(qualities, int offset=*)
 
 ########################################################################
+## String encoding configuration facilities
 ########################################################################
+
+cpdef get_encoding_error_handler()
+cpdef set_encoding_error_handler(name)
+
 ########################################################################
 ## Python 3 compatibility functions
 ########################################################################

--- a/pysam/libcutils.pyx
+++ b/pysam/libcutils.pyx
@@ -6,6 +6,7 @@ import tempfile
 import os
 import io
 from contextlib import contextmanager
+from codecs import register_error
 
 from cpython.version cimport PY_MAJOR_VERSION, PY_MINOR_VERSION
 from cpython cimport PyBytes_Check, PyUnicode_Check
@@ -89,6 +90,8 @@ cpdef qualities_to_qualitystring(qualities, int offset=33):
 def latin1_replace(exception):
     return (chr(exception.object[exception.start]), exception.end)
 
+register_error('pysam.latin1replace', latin1_replace)
+
 
 cdef str ERROR_HANDLER = 'strict'
 
@@ -98,10 +101,6 @@ cpdef get_encoding_error_handler():
 cpdef set_encoding_error_handler(name):
     global ERROR_HANDLER
     previous = ERROR_HANDLER
-    if name.startswith('pysam.'):
-        from codecs import register_error
-        register_error('pysam.latin1replace', latin1_replace)
-
     ERROR_HANDLER = name
     return previous
 
@@ -137,7 +136,7 @@ cdef bytes encode_filename(object filename):
         raise TypeError("Argument must be string or unicode.")
 
 
-cdef bytes force_bytes(object s, encoding=TEXT_ENCODING):
+cdef bytes force_bytes(object s, encoding=None, errors=None):
     """convert string or unicode object to bytes, assuming
     utf8 encoding.
     """
@@ -146,37 +145,37 @@ cdef bytes force_bytes(object s, encoding=TEXT_ENCODING):
     elif PyBytes_Check(s):
         return s
     elif PyUnicode_Check(s):
-        return s.encode(encoding)
+        return s.encode(encoding or TEXT_ENCODING, errors or ERROR_HANDLER)
     else:
         raise TypeError("Argument must be string, bytes or unicode.")
 
 
-cdef charptr_to_str(const char* s, encoding=TEXT_ENCODING):
+cdef charptr_to_str(const char* s, encoding=None, errors=None):
     if s == NULL:
         return None
     if PY_MAJOR_VERSION < 3:
         return s
     else:
-        return s.decode(encoding, ERROR_HANDLER)
+        return s.decode(encoding or TEXT_ENCODING, errors or ERROR_HANDLER)
 
 
-cdef charptr_to_str_w_len(const char* s, size_t n, encoding=TEXT_ENCODING):
+cdef charptr_to_str_w_len(const char* s, size_t n, encoding=None, errors=None):
     if s == NULL:
         return None
     if PY_MAJOR_VERSION < 3:
         return s[:n]
     else:
-        return s[:n].decode(encoding, ERROR_HANDLER)
+        return s[:n].decode(encoding or TEXT_ENCODING, errors or ERROR_HANDLER)
 
 
-cdef bytes charptr_to_bytes(const char* s, encoding=TEXT_ENCODING):
+cdef bytes charptr_to_bytes(const char* s, encoding=None, errors=None):
     if s == NULL:
         return None
     else:
         return s
 
 
-cdef force_str(object s, encoding=TEXT_ENCODING):
+cdef force_str(object s, encoding=None, errors=None):
     """Return s converted to str type of current Python
     (bytes in Py2, unicode in Py3)"""
     if s is None:
@@ -184,10 +183,19 @@ cdef force_str(object s, encoding=TEXT_ENCODING):
     if PY_MAJOR_VERSION < 3:
         return s
     elif PyBytes_Check(s):
-        return s.decode(encoding, ERROR_HANDLER)
+        return s.decode(encoding or TEXT_ENCODING, errors or ERROR_HANDLER)
     else:
         # assume unicode
         return s
+
+
+cdef decode_bytes(bytes s, encoding=None, errors=None):
+    """Return s converted to current Python's str type,
+    always decoding even in Python 2"""
+    if s is None:
+        return None
+    else:
+        return s.decode(encoding or TEXT_ENCODING, errors or ERROR_HANDLER)
 
 
 cpdef parse_region(contig=None,


### PR DESCRIPTION
Python has impressively flexible facilities to control how the [decode() function](https://docs.python.org/3/library/stdtypes.html#bytes.decode) deals with unexpected input.

The easiest way to enable scripts to control pysam's use of the `decode()` function is to expose this as a global variable via getter/setter methods, similarly to the existing `get_verbosity()`/`set_verbosity()`.

For convenience, also define an error handler that simply interprets invalid/unexpected UTF-8 bytes as ISO-8859-1 (Latin-1) characters. Make it available via `set_encoding_error_handler('pysam.latin1replace')`.

Issue #998 is about pysam's basic UTF-8 parsing refusing to parse fields containing Latin-1-encoded accented letters. This PR would allow scripts to parse such fields by adding:

```python
pysam.set_encoding_error_handler('pysam.latin1replace')
```

before calling functions that decode such fields. Other built-in standard error handlers such as `'replace'` and `'backslashreplace'` may also be of interest.

Parsing as UTF-8 and interpreting invalid input as Latin-1 is problematic because two or more adjacent Latin-1 characters can be misinterpreted as a validly UTF-8-encoded unrelated character. (Probably no such Latin-1 strings are intelligible in French or any other language.) Hence it may be better to also expose the encoding used via global getter/setters so that scripts could instead write

```python
pysam.set_encoding('latin-1')
```

to specify that their VCF v4.2 files should NOT be interpreted as UTF-8 but purely as Latin-1.

I have not added such functions because `force_str()` et al's optional arguments are currently buggy — they supply the original value of `TEXT_ENCODING` (UTF-8), not the current value, so there's little point in adding functions to change the value of `TEXT_ENCODING`. But I would be happy to rework the optional `encoding=` arguments and add such a getter/setter (probably IMHO in addition to the error handler one) if other maintainers prefer.