### PR TITLE
Add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+    defaults:
+      run:
+        shell: bash -l {0}  # needed for conda activation
+    env:
+      HTSLIB_CONFIGURE_OPTIONS: "--disable-libcurl"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          channel-priority: strict
+          activate-environment: testenv
+          auto-activate-base: false
+          use-only-tar-bz2: true
+      - run: conda config --add channels bioconda --add channels conda-forge
+      - run: conda install python=${{ matrix.python-version }} cython
+      - name: Create sdist
+        run: python setup.py sdist
+      - name: Ensure sdist does not contain config.h
+        run: "! tar -tf dist/pysam-*.tar.gz | grep '/config.h$'"
+      - name: Install
+        run: python setup.py install
+      - name: Prepare test data
+        run: |
+          conda install "samtools>=1.11" "bcftools>=1.11" "htslib>=1.11" pytest
+          make -C tests/pysam_data
+          make -C tests/cbcf_data
+      - run: pytest


### PR DESCRIPTION
I don’t know if there have been discussions on this, but https://travis-ci.org/ is apparently going away (and it doesn’t seem to be setup correctly anyway at the moment because I don’t see tests running on the two PRs I have submitted), so I suggest that it makes sense to switch to GitHub Actions for testing.

This PR adds an initial workflow. I started to move over more checks from `run_tests_travis.sh`, but then realized that the runtime becomes quite high, and I couldn’t get everything to work, so I thought it’s better to start small.

If there are no objections and if I have time, I would work more on this and move everything into this workflow. Adding deployment (`cibuildwheel` etc.) should also not be too hard hopefully.

The change in the `Makefile` was necessary because `$(shell samtools view)` resulted in an empty string. (`samtools view` always printed the error message `[main_samview] fail to read the header from "-".`)