### PR TITLE
Remove pysam.py as it doesn’t fulfill its purpose

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -54,7 +54,6 @@ include htslib/cram/*.h
 include htslib/os/*.c
 include htslib/os/*.h
 include cy_build.py
-include pysam.py
 include requirements.txt
 
 # documentation

--- a/pysam.py
+++ b/pysam.py
@@ -1,1 +1,0 @@
-raise ImportError('''calling "import pysam" from the source directory is not supported - please import pysam from somewhere else.''')


### PR DESCRIPTION
When running `python3 -c "import pysam"` in the repository root, "pysam.py" is actually ignored because `pysam/__init__.py` exists and is used instead.

I think the risk of a regular user trying to use pysam from a Git clone are quite low nowadays. Also, running `python3 setup.py build_ext -i` actually allows `import pysam` from the repo root to work.