### PR TITLE
Fix build with sphinx 4.0.2

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -201,8 +201,8 @@ htmlhelp_basename = 'samtoolsdoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-    ('index', 'pysam.tex', u'pysam documentation',
-     u'Andreas Heger, Kevin Jacobs, et al.', 'manual'),
+    ('index', 'pysam.tex', 'pysam documentation',
+     'Andreas Heger, Kevin Jacobs, et al.', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of


### PR DESCRIPTION
Without, I get this error:
```
+ sphinx-build-3 doc html
Running Sphinx v4.0.2
Configuration error:
There is a syntax error in your configuration file: invalid syntax (conf.py, line 204)
```