### PR TITLE
Better handling of file iteration errors

### DIFF
--- a/pysam/libcalignmentfile.pyx
+++ b/pysam/libcalignmentfile.pyx
@@ -1853,12 +1853,14 @@ cdef class AlignmentFile(HTSFile):
 
     def __next__(self):
         cdef int ret = self.cnext()
-        if (ret >= 0):
+        if ret >= 0:
             return makeAlignedSegment(self.b, self.header)
+        elif ret == -1:
+            raise StopIteration
         elif ret == -2:
             raise IOError('truncated file')
         else:
-            raise StopIteration
+            raise IOError("error while reading file: {}".format(ret))
 
     ###########################################
     # methods/properties referencing the header
@@ -2145,10 +2147,12 @@ cdef class IteratorRowHead(IteratorRow):
         if ret >= 0:
             self.current_row += 1
             return makeAlignedSegment(self.b, self.header)
+        elif ret == -1:
+            raise StopIteration
         elif ret == -2:
             raise IOError('truncated file')
         else:
-            raise StopIteration
+            raise IOError("error while reading file: {}".format(ret))
 
 
 cdef class IteratorRowAll(IteratorRow):
@@ -2190,10 +2194,12 @@ cdef class IteratorRowAll(IteratorRow):
         cdef int ret = self.cnext()
         if ret >= 0:
             return makeAlignedSegment(self.b, self.header)
+        elif ret == -1:
+            raise StopIteration
         elif ret == -2:
             raise IOError('truncated file')
         else:
-            raise StopIteration
+            raise IOError("error while reading file: {}".format(ret))
 
 
 cdef class IteratorRowAllRefs(IteratorRow):
@@ -2308,10 +2314,12 @@ cdef class IteratorRowSelection(IteratorRow):
         cdef int ret = self.cnext()
         if ret >= 0:
             return makeAlignedSegment(self.b, self.header)
+        elif ret == -1:
+            raise StopIteration
         elif ret == -2:
             raise IOError('truncated file')
         else:
-            raise StopIteration
+            raise IOError("error while reading file: {}".format(ret))
 
 
 cdef int __advance_nofilter(void *data, bam1_t *b):

--- a/tests/AlignmentFile_test.py
+++ b/tests/AlignmentFile_test.py
@@ -1461,6 +1461,18 @@ class TestTruncatedBAM(unittest.TestCase):
         self.assertRaises(IOError, iterall, s)
 
 
+class TestCorruptBAM(unittest.TestCase):
+    """See pull request 1035."""
+
+    def testCorruptBamIterator(self):
+        s = pysam.AlignmentFile(os.path.join(BAM_DATADIR, "ex2_corrupt.bam"))
+
+        def iterall(x):
+            return len([a for a in x])
+
+        self.assertRaises(IOError, iterall, s)
+
+
 COMPARE_BTAG = [100, 1, 91, 0, 7, 101, 0, 201, 96, 204,
                 0, 0, 87, 109, 0, 7, 97, 112, 1, 12, 78,
                 197, 0, 7, 100, 95, 101, 202, 0, 6, 0, 1,

--- a/tests/pysam_data/Makefile
+++ b/tests/pysam_data/Makefile
@@ -17,6 +17,7 @@ all: ex1.pileup.gz \
 	example_bai.bam \
         rg_with_tab.bam \
 	ex2_truncated.bam \
+	ex2_corrupt.bam \
 	empty.bam empty.bam.bai \
 	explicit_index.bam explicit_index.cram \
 	faidx_empty_seq.fq.gz \
@@ -64,6 +65,9 @@ ex1.pileup.gz:ex1.bam ex1.fa
 
 ex2_truncated.bam: ex2.bam
 	head -c 124000 ex2.bam > ex2_truncated.bam
+
+ex2_corrupt.bam: ex2.bam
+	./make_corrupt_bam.sh $< $@
 
 ex1_csi.bam: ex1.bam
 	cp ex1.bam ex1_csi.bam

--- a/tests/pysam_data/make_corrupt_bam.sh
+++ b/tests/pysam_data/make_corrupt_bam.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+
+# Generates a BAM with a specific type of corruption, where a BAM alignment record spans the
+# boundary into a corrupt BGZF block. The other BAMs created in the makefile are generated in such a
+# way that every alignment record is wholly contained within a single BGZF block; corruption of a
+# BGZF block in this case is interpretted by htslib as a "truncation" (return code = -2), whereas
+# the boundary into a corrupt BGZF block being in the middle of an alignment record causes htslib to
+# return different error codes (< -2).
+
+
+INPUT_BAM=$1
+OUTPUT_BAM=$2
+
+# find the start of the second BGZF block since the first block often has only header information;
+# BGZF blocks in BAM files all start with this sequence of bytes: 0x1f 0x8b 0x08 0x04
+OFFSET=$(grep -abo $'\x1f\x8b\x08\x04' $INPUT_BAM | grep -aoP '^\d+' | sed -n 2p)
+
+# decompress the blocks starting at the offset and split off the first ~35kb
+# into one file and the rest into a second (typical decompressed block size is
+# about 64kb)
+tail -c +$(($OFFSET + 1)) $INPUT_BAM | bgzip -dc > _chunk_decompressed
+head -c 35000 < _chunk_decompressed > _chunk1
+tail -c +35001 < _chunk_decompressed > _chunk2
+
+# recompress and corrupt the second chunk with stray null bytes ~5k into the compressed file
+bgzip -c < _chunk2 > _chunk2.bgzip
+dd if=/dev/zero of=_chunk2.bgzip bs=1 seek=5000 count=10 conv=notrunc
+
+# glue everything back together:
+#  * the skipped header
+#  * the uncorrupt 35kb chunk
+#  * the remainder with the corrupt BGZF block
+head -c $OFFSET $INPUT_BAM > $OUTPUT_BAM
+bgzip -c < _chunk1 >> $OUTPUT_BAM
+cat _chunk2.bgzip >> $OUTPUT_BAM
+
+# clean up
+rm _chunk*


### PR DESCRIPTION
For the iteration methods backed internally by `sam_read1`, _all_ return
codes < -1 signify errors which should raise an exception to the user.

***

I recently had a BAM file that had been corrupted somehow during download, but when I iterated over it with `pysam.Samfile`, iteration ended prematurely but silently - that is, no exceptions were thrown when the corrupted region of the BAM was reached, only some warnings were printed to the terminal by htslib. Example output:
```
>>> f = pysam.Samfile("mapped.bam", "rb") ; sum(1 for _ in f)
[E::idx_find_and_load] Could not retrieve index file for 'mapped.bam'
37954048
>>> f = pysam.Samfile("mapped_corrupt.bam", "rb") ; sum(1 for _ in f)
[E::idx_find_and_load] Could not retrieve index file for 'mapped_corrupt.bam'
[E::bgzf_uncompress] CRC32 checksum mismatch
[E::bgzf_read] Read block operation failed with error 33 after 112 of 149 bytes
335960
>>> 
```

This PR adds better error handling in the case of BAM files that are corrupted in ways other than truncation. The underlying [`sam_read1` method](https://github.com/samtools/htslib/blob/f7975f1ac0f55285d53cb4e72424f44f01e70981/htslib/sam.h#L1394-L1399) uses a number of different return codes less than `-1` to indicate error conditions, so the changes here raise `IOError`s if such return codes are encountered. Updated output:
```
>>> f = pysam.Samfile("mapped.bam", "rb") ; sum(1 for _ in f)
[E::idx_find_and_load] Could not retrieve index file for 'mapped.bam'
37954048
>>> f = pysam.Samfile("mapped_corrupt.bam", "rb") ; sum(1 for _ in f)
[E::idx_find_and_load] Could not retrieve index file for 'mapped_corrupt.bam'
[E::bgzf_uncompress] CRC32 checksum mismatch
[E::bgzf_read] Read block operation failed with error 33 after 112 of 149 bytes
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 1, in <genexpr>
  File "pysam/libcalignmentfile.pyx", line 1863, in pysam.libcalignmentfile.AlignmentFile.__next__
OSError: error while reading file: -4
>>> 
```

I also included a script to generate, through the pysam test data Makefile, a BAM file which is corrupted in such a way to reproduce the issue. I can simply check in the BAM file itself if you prefer to not add the clutter of a script.

Thanks for all your great work on this library!