### PR TITLE
Added support for persisting IndexedReads index to disk

### DIFF
--- a/pysam/libcalignmentfile.pyx
+++ b/pysam/libcalignmentfile.pyx
@@ -75,7 +75,7 @@ from pysam.libcutils cimport force_bytes, force_str, charptr_to_str
 from pysam.libcutils cimport encode_filename, from_string_and_size
 from pysam.libcalignedsegment cimport makeAlignedSegment, makePileupColumn
 from pysam.libchtslib cimport HTSFile, hisremote
-
+import json
 if PY_MAJOR_VERSION >= 3:
     from io import StringIO
 else:
@@ -2918,6 +2918,14 @@ cdef class IndexedReads:
             self.htsfile = self.samfile.htsfile
             self.header = samfile.header
             self.owns_samfile = False
+    
+    def store(self, filename):
+        with open(filename, 'w') as f:
+            json.dump(self.index, f)
+    
+    def load(self, filename):
+        with open(filename) as f:
+            self.index = json.load(f)
 
     def build(self):
         '''build the index.'''


### PR DESCRIPTION
I recently came across a situation where I needed to persist the `IndexedReads` index to disk. I was successfully able to do it and wanted to contribute this feature to this repository.

Steps on how to store/load the index

1. How to store the index to the disk

```
>>> from pysam import AlignmentFile, IndexedReads
>>> bam: AlignmentFile = AlignmentFile('examples/sample.bam')
>>> name_index: IndexedReads = IndexedReads(bam)
>>> name_index.build()
>>> name_index.store('/some/path/to/sample.json')
```

2. How to load the index from the disk

```
>>> from pysam import AlignmentFile, IndexedReads
>>> bam: AlignmentFile = AlignmentFile('examples/sample.bam')
>>> name_index: IndexedReads = IndexedReads(bam)
>>> name_index.load('/some/path/to/sample.json')
```


