### PR TITLE
Make "API" a top-level heading

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -2,9 +2,6 @@
 pysam - An interface for reading and writing SAM files
 ======================================================
 
-Introduction
-============
-
 Pysam is a python module that makes it easy to read and manipulate
 mapped short read sequence data stored in SAM/BAM files.  It is a
 lightweight wrapper of the htslib_ C-API.
@@ -130,11 +127,12 @@ More detailed usage instructions is at :ref:`usage`.
 
        The pysam website containing documentation
 
+===
 API
 ===
 
 SAM/BAM/CRAM files
--------------------
+==================
 
 Objects of type :class:`~pysam.AlignmentFile` allow working with
 BAM/SAM formatted files.
@@ -162,7 +160,7 @@ a SAM/BAM file.
 
 
 Tabix files
------------
+===========
 
 :class:`~pysam.TabixFile` opens tabular files that have been
 indexed with tabix_.
@@ -192,13 +190,13 @@ To iterate over tabix files, use :func:`~pysam.tabix_iterator`:
 
 
 Fasta files
------------
+===========
 
 .. autoclass:: pysam.FastaFile
    :members:
 
 Fastq files
------------
+===========
 
 .. autoclass:: pysam.FastxFile
    :members:
@@ -209,7 +207,7 @@ Fastq files
 
 
 VCF files
----------
+=========
 
 .. autoclass:: pysam.VariantFile
    :members:
@@ -224,7 +222,7 @@ VCF files
    :members:
 
 HTSFile
--------
+=======
 
 HTSFile is the base class for :class:`pysam.AlignmentFile` and
 :class:`pysam.VariantFile`.

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -21,7 +21,7 @@ iteration returns a :class:`~pysam.AlignedSegment` object which
 represents a single read along with its fields and optional tags::
 
    for read in samfile.fetch('chr1', 100, 120):
-	print read
+       print read
 
    samfile.close()
 
@@ -38,8 +38,8 @@ You can also write to a :class:`~pysam.AlignmentFile`::
    samfile = pysam.AlignmentFile("ex1.bam", "rb")
    pairedreads = pysam.AlignmentFile("allpaired.bam", "wb", template=samfile)
    for read in samfile.fetch():
-	if read.is_paired:
-		pairedreads.write(read)
+       if read.is_paired:
+           pairedreads.write(read)
 
    pairedreads.close()
    samfile.close()
@@ -189,13 +189,13 @@ To iterate over tabix files, use :func:`~pysam.tabix_iterator`:
    :members:
 
 
-Fasta files
+FASTA files
 ===========
 
 .. autoclass:: pysam.FastaFile
    :members:
 
-Fastq files
+FASTQ files
 ===========
 
 .. autoclass:: pysam.FastxFile
@@ -206,8 +206,8 @@ Fastq files
    :members:
 
 
-VCF files
-=========
+VCF/BCF files
+=============
 
 .. autoclass:: pysam.VariantFile
    :members:


### PR DESCRIPTION
For me, the pysam API is the most important part of the documentation, and I think the "API" section should therefore be at the top level.

I’m suggesting this change because I never seem to be able to find that section on first attempt when browsing the docs, mostly because it is somewhat hidden below the first heading "pysam - An interface for reading and writing SAM files".

While writing this, I realized that there is actually a full table of contents on the landing page https://pysam.readthedocs.io/en/latest/, which would allow me to go to the API section with a single click, but the fact that I haven’t seen it at least a dozen times makes me believe that having it also in menu on the left would be an improvement.