### PR TITLE
Improve `AlignedSegment.__str__` and `print(read)` field display

### DIFF
--- a/pysam/libcalignedsegment.pyx
+++ b/pysam/libcalignedsegment.pyx
@@ -978,13 +978,13 @@ cdef class AlignedSegment:
         # requires a valid header.
         return "\t".join(map(str, (self.query_name,
                                    self.flag,
-                                   self.reference_id,
-                                   self.reference_start,
+                                   "#%d" % self.reference_id if self.reference_id >= 0 else "*",
+                                   self.reference_start + 1,
                                    self.mapping_quality,
                                    self.cigarstring,
-                                   self.next_reference_id,
-                                   self.next_reference_start,
-                                   self.query_alignment_length,
+                                   "#%d" % self.next_reference_id if self.next_reference_id >= 0 else "*",
+                                   self.next_reference_start + 1,
+                                   self.template_length,
                                    self.query_sequence,
                                    self.query_qualities,
                                    self.tags)))


### PR DESCRIPTION
This patch applies `s/query_alignment_length/template_length/` so fixes #1040. While in the neighbourhood, it also proposes altering the display of the RNAME, POS, RNEXT, and PNEXT fields.

The `__str__` function (also used when you simply `print` an AlignedSegment object) is a simplified way of printing an alignment record, and takes some shortcuts because a set of headers might not be available.

For full writing or printing of a SAM record, you would be writing to an `AlignmentFile` or using `rec.to_string()`, both of which take advantage of headers to print the chromosome names and use htslib facilities to print the record in proper SAM format.

`__str__` prints a half-internal form of this: RNAME/RNEXT are shown as the `tid` integer (i.e. 0 ≤ _tid_ < _nchroms_) instead of the actual chromosome name; base qualities and tagged fields are shown as Python arrays; and POS and PNEXT (aka MPOS) are shown as their raw internal values, i.e., 0-based.

Thus `__str__` and `print()` produce a line that mostly (up to the SEQ column anyway) looks a lot like real SAM, but the chromosome ids are numeric and the positions are 0-based.

This PR changes the format output by `__str__` and `print()` by printing RNAME/RNEXT with a `#` prefix to avoid confusion with `1`, `2`, etc non-“chr”-prefixed actual chromosome names, and as `*` for unmapped; and writing POS/PNEXT as 1-based values as is familiar in a textual SAM record context.

```python
for read in samfile:
    print(read)
    print(read.to_string())
    print()
```

Previously this script would output the following for a [simple test SAM file](https://github.com/pysam-developers/pysam/files/7162170/i1040.sam.txt):

```
one	0	0	99	15	4M	0	199	4	ATGC	array('B', [64, 65, 66, 67])	[('X0', 37)]
one	0	apple	100	15	4M	=	200	101	ATGC	abcd	X0:i:37

two	0	1	199	64	4M	1	399	4	CGAT	array('B', [68, 69, 70, 71])	[]
two	0	banana	200	64	4M	=	400	201	CGAT	efgh

three	0	1	299	40	2M	0	99	2	AT	array('B', [73, 72])	[]
three	0	banana	300	40	2M	apple	100	0	AT	ji

four	4	-1	-1	0	4M	-1	-1	4	TTAG	array('B', [74, 75, 76, 77])	[]
four	4	*	0	0	4M	*	0	0	TTAG	klmn
```
&nbsp;
With this PR, the second line for each read is unchanged but the `print(read)` line differs:
```
one	0	#0	100	15	4M	#0	200	101	ATGC	array('B', [64, 65, 66, 67])	[('X0', 37)]
one	0	apple	100	15	4M	=	200	101	ATGC	abcd	X0:i:37

two	0	#1	200	64	4M	#1	400	201	CGAT	array('B', [68, 69, 70, 71])	[]
two	0	banana	200	64	4M	=	400	201	CGAT	efgh

three	0	#1	300	40	2M	#0	100	0	AT	array('B', [73, 72])	[]
three	0	banana	300	40	2M	apple	100	0	AT	ji

four	4	*	0	0	4M	*	0	0	TTAG	array('B', [74, 75, 76, 77])	[]
four	4	*	0	0	4M	*	0	0	TTAG	klmn
```
&nbsp;
Notice that the various -1s are gone, the numeric chromosome “names” are more distinctive, the positions are as expected from the `.to_string()` line, and the TLEN field is corrected.

This is an **incompatible change in the `__str__` output**, but as this is a half-internal format being printed it will usually be used just for debugging etc. Any real data interchange would be being done with `AlignmentFile` or `.to_string()` and be unchanged. So the claim is that this change will only make debugging output easier to read and won't have adverse effects (despite being officially an incompatible change in output).

@AndreasHeger @kevinjacobs-progenity @marcelm Any issues with applying this change?

The alternative would be to fix the TLEN field and, instead of altering POS/PEXT, add a note to the documentation about them being  0-based:
https://github.com/pysam-developers/pysam/blob/92f8a51fa49ab5e8c8d72750ff3adef0bc4a9a48/pysam/libcalignedsegment.pyx#L970-L973