### PR TITLE
baseimage for containers

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,13 @@
+FROM ubi8:latest
+
+RUN yum update \
+  && yum install -y python3-pip python3-devel pigz \
+  && cd /usr/local/bin \
+  && ln -s /usr/bin/python3 python \
+  && pip3 --no-cache-dir install --upgrade pip \
+  && yum clean all \
+  && echo "system packages installed"
+
+RUN python -m pip install pysam
+
+WORKDIR /opt/


### PR DESCRIPTION
After running into #1044 I've started exploring this path. And here the installation "just worked". If we provide a base image with the pysam package then people can build their tooling on top of that baseimage in any OS that runs containers in a similar fashion.

I built and tested it this way:

```
$ podman build -t pysam -f Containerfile .
$ podman run -it pysam python -c "import pysam; print('woohoo')"
```

Let me know what you think.