### PR TITLE
Run flake8 and fix some linting issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Install dependencies
         run: python -m pip install flake8
       - name: Run flake8
-        run: flake8 pysam/ tests/
+        run: flake8 pysam/ tests/ *.py
 
   direct:
     runs-on: ${{ matrix.os }}-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,19 @@ name: CI
 on: [push, pull_request]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: python -m pip install flake8
+      - name: Run flake8
+        run: flake8 pysam/ tests/
+
   direct:
     runs-on: ${{ matrix.os }}-latest
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,19 +3,6 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.10"
-      - name: Install dependencies
-        run: python -m pip install flake8
-      - name: Run flake8
-        run: flake8 pysam/ tests/ *.py
-
   direct:
     runs-on: ${{ matrix.os }}-latest
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.10"
       - name: Install dependencies
         run: python -m pip install flake8
       - name: Run flake8

--- a/cy_build.py
+++ b/cy_build.py
@@ -8,7 +8,7 @@ except ImportError:
     from setuptools.command.build_ext import build_ext
 
 from distutils.extension import Extension
-from distutils.sysconfig import get_config_vars, get_python_lib, get_python_version
+from distutils.sysconfig import get_config_vars, get_python_version
 from pkg_resources import Distribution
 
 

--- a/pysam/__init__.py
+++ b/pysam/__init__.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import sysconfig
 
 from pysam.libchtslib import *

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,38 @@ universal = 0
 # -v: verbose output
 addopts = -s -v
 testpaths = pysam tests
+
+[flake8]
+max-line-length = 100
+max-complexity = 23
+extend-ignore = E111, E117, E124, E125, E201, E202, E211, E225, E231, E265, E266, E302, E303, E305, E402, E501, E713, E722, E741, F401, F403, F405, F811, F821, F841, W291, W293, W391, W605
+
+# E111 indentation is not a multiple of
+# E117 over-indented
+# E124 closing bracket does not match visual indentation
+# E125 continuation line with same indent as next logical line
+# E201 whitespace after '{'
+# E202 whitespace before '}'
+# E211 whitespace before '('
+# E225 missing whitespace around operator
+# E231 missing whitespace after ':'
+# E265 block comment should start with '# '
+# E266 too many leading '#' for block comment
+# E302 expected 2 blank lines, found 1
+# E303 too many blank lines
+# E305 expected 2 blank lines after class or function definition, found 1
+# E402 module level import not at top of file
+# E501 line too long
+# E713 test for membership should be 'not in'
+# E722 do not use bare 'except'
+# E741 ambiguous variable name '...'
+# F401 '...' imported but unused
+# F403 'from ... import *' used; unable to detect undefined names
+# F405 '...' may be undefined, or defined from star imports: ...
+# F811 redefinition of unused '...' from line ...
+# F821 undefined name '...'
+# F841 local variable '...' is assigned to but never used
+# W291 trailing whitespace
+# W293 blank line contains whitespace
+# W391 blank line at end of file
+# W605 invalid escape sequence '...'

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,10 +10,9 @@ testpaths = pysam tests
 [flake8]
 max-line-length = 100
 max-complexity = 23
-extend-ignore = E111, E117, E124, E125, E201, E202, E211, E225, E231, E265, E266, E302, E303, E305, E402, E501, E713, E722, E741, F403, F405, F811, F821, F841, W291, W293, W391, W605
+extend-ignore = E117, E124, E125, E201, E202, E211, E225, E231, E265, E266, E302, E303, E305, E402, E501, E713, E722, E741, F403, F405, F811, F821, F841, W291, W293, W391, W605
 per-file-ignores = __init__.py:F401
 
-# E111 indentation is not a multiple of
 # E117 over-indented
 # E124 closing bracket does not match visual indentation
 # E125 continuation line with same indent as next logical line

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,5 +6,3 @@ universal = 0
 # -v: verbose output
 addopts = -s -v
 testpaths = pysam tests
-pep8maxlinelength = 120
-pep8ignore = E402

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,8 @@ testpaths = pysam tests
 [flake8]
 max-line-length = 100
 max-complexity = 23
-extend-ignore = E111, E117, E124, E125, E201, E202, E211, E225, E231, E265, E266, E302, E303, E305, E402, E501, E713, E722, E741, F401, F403, F405, F811, F821, F841, W291, W293, W391, W605
+extend-ignore = E111, E117, E124, E125, E201, E202, E211, E225, E231, E265, E266, E302, E303, E305, E402, E501, E713, E722, E741, F403, F405, F811, F821, F841, W291, W293, W391, W605
+per-file-ignores = __init__.py:F401
 
 # E111 indentation is not a multiple of
 # E117 over-indented
@@ -31,7 +32,6 @@ extend-ignore = E111, E117, E124, E125, E201, E202, E211, E225, E231, E265, E266
 # E713 test for membership should be 'not in'
 # E722 do not use bare 'except'
 # E741 ambiguous variable name '...'
-# F401 '...' imported but unused
 # F403 'from ... import *' used; unable to detect undefined names
 # F405 '...' may be undefined, or defined from star imports: ...
 # F811 redefinition of unused '...' from line ...

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ testpaths = pysam tests
 [flake8]
 max-line-length = 100
 max-complexity = 23
-extend-ignore = E117, E124, E125, E201, E202, E211, E225, E231, E265, E266, E302, E303, E305, E402, E501, E713, E722, E741, F403, F405, F811, F821, F841, W291, W293, W391, W605
+extend-ignore = E117, E124, E125, E201, E202, E211, E225, E231, E265, E266, E302, E303, E305, E402, E501, E701, E713, E722, E741, F403, F405, F811, F821, F841, W291, W293, W391, W605
 per-file-ignores = __init__.py:F401
 
 # E117 over-indented
@@ -28,6 +28,7 @@ per-file-ignores = __init__.py:F401
 # E305 expected 2 blank lines after class or function definition, found 1
 # E402 module level import not at top of file
 # E501 line too long
+# E701 multiple statements on one line (colon)
 # E713 test for membership should be 'not in'
 # E722 do not use bare 'except'
 # E741 ambiguous variable name '...'

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ from setuptools.command.sdist import sdist
 
 from cy_build import CyExtension as Extension, cy_build_ext as build_ext
 try:
-    import cython
+    import cython  # noqa
     HAVE_CYTHON = True
 except ImportError:
     HAVE_CYTHON = False
@@ -142,10 +142,10 @@ def set_compiler_envvars():
     tmp_vars = []
     for var in ['CC', 'CFLAGS', 'LDFLAGS']:
         if var in os.environ:
-            print ("# pysam: (env) {}={}".format(var, os.environ[var]))
+            print("# pysam: (env) {}={}".format(var, os.environ[var]))
         elif var in sysconfig.get_config_vars():
             value = sysconfig.get_config_var(var)
-            print ("# pysam: (sysconfig) {}={}".format(var, value))
+            print("# pysam: (sysconfig) {}={}".format(var, value))
             os.environ[var] = value
             tmp_vars += [var]
 
@@ -272,10 +272,10 @@ config_headers = ["samtools/config.h",
 # the .pyx files. If no cython is available, the C-files included in the
 # distribution will be used.
 if HAVE_CYTHON:
-    print ("# pysam: cython is available - using cythonize if necessary")
+    print("# pysam: cython is available - using cythonize if necessary")
     source_pattern = "pysam/libc%s.pyx"
 else:
-    print ("# pysam: no cython available - using pre-compiled C")
+    print("# pysam: no cython available - using pre-compiled C")
     source_pattern = "pysam/libc%s.c"
 
 # Exit if there are no pre-compiled files and no cython available
@@ -287,8 +287,8 @@ if not os.path.exists(fn):
         "from the repository"
         .format(fn))
 
-print ("# pysam: htslib mode is {}".format(HTSLIB_MODE))
-print ("# pysam: HTSLIB_CONFIGURE_OPTIONS={}".format(
+print("# pysam: htslib mode is {}".format(HTSLIB_MODE))
+print("# pysam: HTSLIB_CONFIGURE_OPTIONS={}".format(
     HTSLIB_CONFIGURE_OPTIONS))
 htslib_configure_options = None
 
@@ -304,7 +304,7 @@ if HTSLIB_MODE in ['shared', 'separate']:
          "--disable-libcurl"])
 
     HTSLIB_SOURCE = "builtin"
-    print ("# pysam: htslib configure options: {}".format(
+    print("# pysam: htslib configure options: {}".format(
         str(htslib_configure_options)))
 
     config_headers += ["htslib/config.h"]
@@ -320,7 +320,7 @@ if HTSLIB_MODE in ['shared', 'separate']:
         htslib_make_options = run_make_print_config()
 
     for key, value in htslib_make_options.items():
-        print ("# pysam: htslib_config {}={}".format(key, value))
+        print("# pysam: htslib_config {}={}".format(key, value))
 
     external_htslib_libraries = ['z']
     if "LIBS" in htslib_make_options:
@@ -385,7 +385,7 @@ with open(os.path.join("pysam", "config.py"), "w") as outf:
                         "HAVE_LIBLZMA",
                         "HAVE_MMAP"]:
                 outf.write("{} = {}\n".format(key, config_values[key]))
-                print ("# pysam: config_option: {}={}".format(key, config_values[key]))
+                print("# pysam: config_option: {}={}".format(key, config_values[key]))
 
 # create empty config.h files if they have not been created automatically
 # or created by the user:

--- a/tests/AlignmentFileFetchTestUtils.py
+++ b/tests/AlignmentFileFetchTestUtils.py
@@ -2,7 +2,8 @@ import os
 import subprocess
 import pysam
 
-from TestUtils import BAM_DATADIR, force_str
+from TestUtils import force_str
+
 
 def build_fetch_with_samtoolsshell(fn):
     retval = os.popen("samtools view {} 2> /dev/null | wc -l".format(fn)).read()

--- a/tests/AlignmentFileFetch_bench.py
+++ b/tests/AlignmentFileFetch_bench.py
@@ -1,9 +1,8 @@
 """Benchmarking module for AlignmentFile functionality"""
-import os
 import pytest
 
 
-from TestUtils import BAM_DATADIR, force_str, flatten_nested_list
+from TestUtils import BAM_DATADIR
 from AlignmentFileFetchTestUtils import *
 
 

--- a/tests/AlignmentFileHeader_test.py
+++ b/tests/AlignmentFileHeader_test.py
@@ -7,18 +7,12 @@ and data files located there.
 
 import unittest
 import os
-import sys
 import re
 import copy
 from collections import OrderedDict as odict
 import pysam
 import pysam.samtools
 from TestUtils import get_temp_filename, make_data_files, BAM_DATADIR
-
-if sys.version_info.major >= 3:
-    from io import StringIO
-else:
-    from StringIO import StringIO
 
 
 def setUpModule():

--- a/tests/AlignmentFilePileup_bench.py
+++ b/tests/AlignmentFilePileup_bench.py
@@ -1,7 +1,5 @@
 """Benchmarking module for AlignmentFile functionality"""
-import os
-
-from TestUtils import BAM_DATADIR, force_str, flatten_nested_list
+from TestUtils import BAM_DATADIR, flatten_nested_list
 from PileupTestUtils import *
 
 

--- a/tests/PileupTestUtils.py
+++ b/tests/PileupTestUtils.py
@@ -2,7 +2,8 @@ import os
 import subprocess
 import pysam
 
-from TestUtils import BAM_DATADIR, force_str
+from TestUtils import force_str
+
 
 def build_pileup_with_samtoolsshell(fn):
     os.system("samtools mpileup {} 2> /dev/null | wc -l > /dev/null".format(fn))

--- a/tests/TestUtils.py
+++ b/tests/TestUtils.py
@@ -1,7 +1,6 @@
 import sys
 import os
 import glob
-import difflib
 import gzip
 import contextlib
 import inspect

--- a/tests/VariantFileFetchTestUtils.py
+++ b/tests/VariantFileFetchTestUtils.py
@@ -8,8 +8,6 @@ except ImportError:
     pass
     
 
-from TestUtils import CBCF_DATADIR, force_str
-
 def build_filter_from_vcf_with_samtoolsshell(fn):
     retval = os.popen(
         "bcftools filter -e \"N_ALT != 1 || QUAL < 20 || maf[0]>0.05\" {} | grep -cv ^# ".format(fn)).read()

--- a/tests/VariantFile_bench.py
+++ b/tests/VariantFile_bench.py
@@ -1,9 +1,7 @@
 """Benchmarking module for AlignmentFile functionality"""
-import os
 import pytest
 
 
-from TestUtils import BAM_DATADIR, force_str, flatten_nested_list
 from VariantFileFetchTestUtils import *
 
 

--- a/tests/VariantFile_test.py
+++ b/tests/VariantFile_test.py
@@ -615,10 +615,10 @@ class TestMultiThreading(unittest.TestCase):
 
     def testSingleThreadEqualsMultithreadResult(self):
         with pysam.VariantFile(self.filename) as inf:
-             header = inf.header
-             single = [r for r in inf]
+            header = inf.header
+            single = [r for r in inf]
         with pysam.VariantFile(self.filename, threads=2) as inf:
-             multi = [r for r in inf]
+            multi = [r for r in inf]
         for r1, r2 in zip(single, multi):
             assert str(r1) == str(r2)
 

--- a/tests/VariantRecord_test.py
+++ b/tests/VariantRecord_test.py
@@ -1,11 +1,4 @@
-import os
-import glob
-import sys
-import unittest
 import pysam
-import shutil
-import gzip
-import subprocess
 import pytest
 
 try:
@@ -13,7 +6,7 @@ try:
 except ImportError:
     Path = None
 
-from TestUtils import get_temp_filename, check_lines_equal, load_and_convert, make_data_files, CBCF_DATADIR, get_temp_context
+from TestUtils import make_data_files, CBCF_DATADIR
 
 
 def setUpModule():

--- a/tests/faidx_test.py
+++ b/tests/faidx_test.py
@@ -1,5 +1,4 @@
 import pysam
-import pytest
 import unittest
 import os
 import gzip

--- a/tests/tabixproxies_test.py
+++ b/tests/tabixproxies_test.py
@@ -1,7 +1,6 @@
 import unittest
 import pysam
 import os
-import sys
 import re
 import copy
 import gzip

--- a/tests/test_samtools_python.py
+++ b/tests/test_samtools_python.py
@@ -1,6 +1,5 @@
 import pysam
 import os
-import pytest
 from TestUtils import make_data_files, BAM_DATADIR
 
 


### PR DESCRIPTION
Whenever I open up the pysam source code in PyCharm, I get a lot of warnings from the built-in code style checker: Unused imports, weird indentation, too many blank lines, trailing whitespace etc. ... I have somewhat gotten used to working with code that uses an automatic style checker, mostly flake8, so I wonder if this would be something that could be considered for pysam.

In this PR, I’ve
- added a "lint" job to the GitHub Action workflow that runs `flake8`
- configured `flake8` to ignore all the existing problems it finds
- re-enabled a couple of these checks while at the same time fixing them in the source code

The idea is to re-enable the checks one by one. I can do this for some of the checks if there’s interest.

I’m aware that style checking is a matter of personal preference, and perhaps it’s not desirable to have CI fail "just" because of style issues, so I’m perfectly ok if this doesn’t get accepted.

(I use Black in other projects, but didn’t want to bring this up, yet, but it’s of course another option.)