### PR TITLE
Improve getopt()/getopt_long() resetting when running samtools/bcftools commands

### DIFF
--- a/bcftools/bcftools.pysam.c
+++ b/bcftools/bcftools.pysam.c
@@ -1,5 +1,4 @@
-#include <ctype.h>
-#include <assert.h>
+#include <getopt.h>
 #include <unistd.h>
 #include <setjmp.h>
 #include <stdio.h>
@@ -62,6 +61,15 @@ static int bcftools_status = 0;
 
 int bcftools_dispatch(int argc, char *argv[])
 {
+  /* Reset getopt()/getopt_long() processing. */
+#if defined __GLIBC__
+  optind = 0;
+#elif defined _OPTRESET || defined _OPTRESET_DECLARED
+  optreset = optind = 1;
+#else
+  optind = 1;
+#endif
+
   if (setjmp(bcftools_jmpbuf) == 0)
     return bcftools_main(argc, argv);
   else
@@ -73,17 +81,3 @@ void bcftools_exit(int status)
   bcftools_status = status;
   longjmp(bcftools_jmpbuf, 1);
 }
-
-
-void bcftools_set_optind(int val)
-{
-  // setting this in cython via 
-  // "from posix.unistd cimport optind"
-  // did not work.
-  //
-  // setting to 0 forces a complete re-initialization
-  optind = val;
-}
-
-
-

--- a/bcftools/bcftools.pysam.h
+++ b/bcftools/bcftools.pysam.h
@@ -53,8 +53,6 @@ int bcftools_dispatch(int argc, char *argv[]);
 
 void PYSAM_NORETURN bcftools_exit(int status);
 
-void bcftools_set_optind(int);
-
 extern int bcftools_main(int argc, char *argv[]);
 
 /* Define these only in samtools/bcftools C source, not Cython code. */

--- a/import/pysam.c
+++ b/import/pysam.c
@@ -1,5 +1,4 @@
-#include <ctype.h>
-#include <assert.h>
+#include <getopt.h>
 #include <unistd.h>
 #include <setjmp.h>
 #include <stdio.h>
@@ -62,6 +61,15 @@ static int @pysam@_status = 0;
 
 int @pysam@_dispatch(int argc, char *argv[])
 {
+  /* Reset getopt()/getopt_long() processing. */
+#if defined __GLIBC__
+  optind = 0;
+#elif defined _OPTRESET || defined _OPTRESET_DECLARED
+  optreset = optind = 1;
+#else
+  optind = 1;
+#endif
+
   if (setjmp(@pysam@_jmpbuf) == 0)
     return @pysam@_main(argc, argv);
   else
@@ -73,17 +81,3 @@ void @pysam@_exit(int status)
   @pysam@_status = status;
   longjmp(@pysam@_jmpbuf, 1);
 }
-
-
-void @pysam@_set_optind(int val)
-{
-  // setting this in cython via 
-  // "from posix.unistd cimport optind"
-  // did not work.
-  //
-  // setting to 0 forces a complete re-initialization
-  optind = val;
-}
-
-
-

--- a/import/pysam.h
+++ b/import/pysam.h
@@ -53,8 +53,6 @@ int @pysam@_dispatch(int argc, char *argv[]);
 
 void PYSAM_NORETURN @pysam@_exit(int status);
 
-void @pysam@_set_optind(int);
-
 extern int @pysam@_main(int argc, char *argv[]);
 
 /* Define these only in samtools/bcftools C source, not Cython code. */

--- a/pysam/libcbcftools.pxd
+++ b/pysam/libcbcftools.pxd
@@ -6,4 +6,3 @@ cdef extern from "bcftools.pysam.h":
     void bcftools_set_stdout(int fd)
     void bcftools_set_stdout_fn(const char *)
     void bcftools_close_stdout()
-    void bcftools_set_optind(int)

--- a/pysam/libcsamtools.pxd
+++ b/pysam/libcsamtools.pxd
@@ -6,4 +6,3 @@ cdef extern from "samtools.pysam.h":
     void samtools_set_stdout(int fd)
     void samtools_set_stdout_fn(const char *)
     void samtools_close_stdout()
-    void samtools_set_optind(int)

--- a/pysam/libcutils.pyx
+++ b/pysam/libcutils.pyx
@@ -19,10 +19,10 @@ from libc.stdio cimport stdout as c_stdout
 from posix.fcntl cimport open as c_open, O_WRONLY
 
 from libcsamtools cimport samtools_dispatch, samtools_set_stdout, samtools_set_stderr, \
-    samtools_close_stdout, samtools_close_stderr, samtools_set_stdout_fn, samtools_set_optind
+    samtools_close_stdout, samtools_close_stderr, samtools_set_stdout_fn
 
 from libcbcftools cimport bcftools_dispatch, bcftools_set_stdout, bcftools_set_stderr, \
-    bcftools_close_stdout, bcftools_close_stderr, bcftools_set_stdout_fn, bcftools_set_optind
+    bcftools_close_stdout, bcftools_close_stderr, bcftools_set_stdout_fn
 
 #####################################################################
 # hard-coded constants
@@ -401,16 +401,6 @@ def _pysam_dispatch(collection,
         l = len(args[i])
         cargs[i + 2] = <char *>calloc(l + 1, sizeof(char))
         strncpy(cargs[i + 2], args[i], l)
-    
-    # reset getopt. On OsX there getopt reset is different
-    # between getopt and getopt_long
-    if method in [b'index', b'cat', b'quickcheck',
-                  b'faidx', b'kprobaln']:
-        samtools_set_optind(1)
-        bcftools_set_optind(1)
-    else:
-        samtools_set_optind(0)
-        bcftools_set_optind(0)
 
     # call samtools/bcftools
     if collection == b"samtools":

--- a/samtools/samtools.pysam.c
+++ b/samtools/samtools.pysam.c
@@ -1,5 +1,4 @@
-#include <ctype.h>
-#include <assert.h>
+#include <getopt.h>
 #include <unistd.h>
 #include <setjmp.h>
 #include <stdio.h>
@@ -62,6 +61,15 @@ static int samtools_status = 0;
 
 int samtools_dispatch(int argc, char *argv[])
 {
+  /* Reset getopt()/getopt_long() processing. */
+#if defined __GLIBC__
+  optind = 0;
+#elif defined _OPTRESET || defined _OPTRESET_DECLARED
+  optreset = optind = 1;
+#else
+  optind = 1;
+#endif
+
   if (setjmp(samtools_jmpbuf) == 0)
     return samtools_main(argc, argv);
   else
@@ -73,17 +81,3 @@ void samtools_exit(int status)
   samtools_status = status;
   longjmp(samtools_jmpbuf, 1);
 }
-
-
-void samtools_set_optind(int val)
-{
-  // setting this in cython via 
-  // "from posix.unistd cimport optind"
-  // did not work.
-  //
-  // setting to 0 forces a complete re-initialization
-  optind = val;
-}
-
-
-

--- a/samtools/samtools.pysam.h
+++ b/samtools/samtools.pysam.h
@@ -53,8 +53,6 @@ int samtools_dispatch(int argc, char *argv[]);
 
 void PYSAM_NORETURN samtools_exit(int status);
 
-void samtools_set_optind(int);
-
 extern int samtools_main(int argc, char *argv[]);
 
 /* Define these only in samtools/bcftools C source, not Cython code. */


### PR DESCRIPTION
The `getopt()` and `getopt_long()` functions have internal state tracking the option parsing that needs to be reset when user code wants to start processing a different `argc`/`argv` pair, i.e., when running a samtools or bcftools command (apart from the first time such a command is run in a Python session).

7954ff1a6df7a4a7e088e7b17bfd4e9868bb94dc improved resetting on macOS but broke it on Linux. This PR rewrites it to work on both platforms. Resetting is not standardised by POSIX but varies by C library:

* GNU libc defines its own way by setting `optind` to 0. (This is barely documented, but is described in the _getopt.h_ header.)
* BSD-derived systems use an extra `optreset` variable, which can be detected via a preprocessor symbol: some BSDs define `_OPTRESET_DECLARED`, while macOS has defined `_OPTRESET` since 10.4 (Tiger).
* Otherwise the best attempt just sets `optind` to 1.

This PR adds those three variants to `@pysam@_dispatch()` and reruns `devtools/import.py` to regenerate the samtools/bcftools files derived from _pysam/import.c_. Fixes #813 and fixes #1084.

Because this affects the same imported files as PR #1083, the best way to apply it will be to merge #1083 first and then rebase (and re-import) this on top of the 1.15 import. Hence this PR is left as draft until then.