### PR TITLE
Fix type of VariantHeaderMetadata add

### DIFF
--- a/pysam/libcbcf.pyi
+++ b/pysam/libcbcf.pyi
@@ -86,7 +86,7 @@ class VariantHeaderMetadata(_Mapping[str, VariantMetadata]):
     def add(
         self,
         id: str,
-        number: Optional[str],
+        number: Optional[Union[int, str]],
         type: Optional[str],
         description: str,
         **kwargs


### PR DESCRIPTION
Gets made into a string here:
https://github.com/pysam-developers/pysam/blob/5eac009c5e85d280e8bbcb69ed0fa081e2271d78/pysam/libcbcf.pyx#L1587