### PR TITLE
Fix setting sample genotype using .alleles property

### DIFF
--- a/tests/VariantRecord_test.py
+++ b/tests/VariantRecord_test.py
@@ -66,3 +66,30 @@ def test_unicode_annotation_can_be_added(vcf_header):
     assert str(record)[:-1].split("\t")[-2:] == [
         "anno1",
         "Friedrich-Alexander-Universit\u00E4t_Erlangen-N\u00FCrnberg"]
+
+def test_set_sample_alleles(vcf_header):
+    vcf_header.formats.add('GT',1,'String',"Genotype") # id, number, type, description
+    record = vcf_header.new_record(
+        contig="1",
+        start=20,
+        stop=21,
+        alleles=('A','T')
+        )
+
+    record.samples['sample1'].alleles = ('T', 'A')
+    assert record.samples['sample1'].alleles  == ('T','A')
+
+    # Empty record:
+    record.samples['sample1'].alleles = (None, )
+    assert record.samples['sample1'].alleles   == tuple()
+    record.samples['sample1'].alleles = None
+    assert record.samples['sample1'].alleles   == tuple()
+    record.samples['sample1'].alleles = tuple()
+    assert record.samples['sample1'].alleles   == tuple()
+
+    # check error conditions:
+    with pytest.raises(ValueError, match='One or more of the supplied sample alleles are not defined'):
+        record.samples['sample1'].alleles = ('C', 'A')
+
+    with pytest.raises(ValueError, match='Use .allele_indices to set integer allele indices'):
+        record.samples['sample1'].alleles = (1, 0)


### PR DESCRIPTION
This is a fix for issue #891 .

The cause of the issue is that in `libcbcf.pyx`  the `@alleles.setter` method is identical to the `@allele_indices.setter` method, while it should calculate the the allele indices and write these to the GT. 
I have included a test to check the correct behavior.
Additionally there is some code to allow the GT to be reset by passing `None` an empty tuple or a `(None,)` tuple, and finally an assertion to check if no integers are passed to inform (potential) users which expect the old but incorrect behavior. 
