### PR TITLE
Add a minimal pyproject.toml for PEP517 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "pysam"
+description = "pysam - a python module for reading, manipulating and writing genomic data sets."
+version = "0.20.0"
+authors = [
+ { name = "Andreas Heger", email = "andreas.heger@gmail.com"}
+]
+requires-python = ">=3.8"
+
+dependencies = [
+    "cython",
+]
+
+
+[build-system]
+requires = ["setuptools>=61.0", "wheel", "Cython>=0.29.30,<3.0"]
+build-backend = "setuptools.build_meta:__legacy__"


### PR DESCRIPTION
This PR allows pip isolated builds to work, but still uses the same build infrastructure as always, so shouldn't break anything.

I needed this because I develop a pipeline running on python 3.11, for which there isn't a wheel yet. The dependency manager I'm using ([poetry](https://python-poetry.org/)) does all its builds in isolated environments, which is fine when `setup.py` doesn't depend on anything except `setuptools` and/or `wheel` but has problems when you need e.g. `cython`

The solution is to add a minimal `pyproject.toml` file that includes the build dependencies, and specifies the correct build backend. That way, the isolated enviroment used for the build ends up with Cython, and everyone is happy.

I added some stuff to the project description, but this is all already in `setup.cfg` I think, so could be removed. Ideally, everything would end up in the `pyproject.toml` but I didn't want to break anything since I'm not 100% sure how this all interacts with e.g.  CI and pushing to PyPI.

