### PR TITLE
Remove cython from runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,6 @@ dynamic = [
     "readme",
 ]
 
-dependencies = [
-    "cython",
-]
-
-
 [build-system]
-requires = ["setuptools>=59.0", "wheel", "Cython>=0.29.30,<3.0"]
+requires = ["setuptools>=59.0", "wheel", "Cython>=0.29.12"]
 build-backend = "setuptools.build_meta:__legacy__"


### PR DESCRIPTION
It's only needed at build time.

Should fix https://github.com/galaxyproject/galaxy/pull/15942/files#r1167475501