### PR TITLE
Remove cython runtime dependency from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ dynamic = [
     "readme",
 ]
 
-
 [build-system]
 requires = ["setuptools>=59.0", "wheel", "Cython>=0.29.30,<3.0"]
 build-backend = "setuptools.build_meta:__legacy__"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,6 @@ dynamic = [
     "readme",
 ]
 
-dependencies = [
-    "cython",
-]
-
 
 [build-system]
 requires = ["setuptools>=59.0", "wheel", "Cython>=0.29.30,<3.0"]


### PR DESCRIPTION
Since `cython` is a build-time dependency but not a runtime dependency, I think it only needs to be included in the `build-system.requires` section of the pyproject.toml ([source](https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/#build-time-dependencies)). So it probably shouldn't be listed in the `project.dependencies` section?

## Testing
I tried a few things to ensure that it didn't need to be listed.

First, I enabled github actions on my fork of this repository to build sdists from this PR. Next, I ran the following in an empty conda environment on my local system.
```
pip install git+https://github.com/aryarm/pysam.git@v0.21.1
```
In both cases, I was able to build an sdist and install/run the package correctly despite not having `cython` listed as a runtime dependency.

Feel free to let me know if there's anything else that you'd like me to try when testing. Thanks for considering this PR!