### PR TITLE
samtools/*.c: fix a couple of typos.

### DIFF
--- a/samtools/bam_ampliconclip.c
+++ b/samtools/bam_ampliconclip.c
@@ -1014,7 +1014,7 @@ int amplicon_clip_main(int argc, char **argv) {
 
     if (param.tol < 0) {
         fprintf(stderr, "[ampliconclip] warning: invalid tolerance of %d,"
-                        " reseting tolerance to default of 5.\n", param.tol);
+                        " resetting tolerance to default of 5.\n", param.tol);
         param.tol = 5;
     }
 

--- a/samtools/bam_ampliconclip.c.pysam.c
+++ b/samtools/bam_ampliconclip.c.pysam.c
@@ -1016,7 +1016,7 @@ int amplicon_clip_main(int argc, char **argv) {
 
     if (param.tol < 0) {
         fprintf(samtools_stderr, "[ampliconclip] warning: invalid tolerance of %d,"
-                        " reseting tolerance to default of 5.\n", param.tol);
+                        " resetting tolerance to default of 5.\n", param.tol);
         param.tol = 5;
     }
 

--- a/samtools/bamshuf.c
+++ b/samtools/bamshuf.c
@@ -537,7 +537,7 @@ static int usage(FILE *fp, int n_files, int reads_store) {
             "      -l INT   Compression level [%d]\n" // DEF_CLEVEL
             "      -n INT   Number of temporary files [%d]\n" // n_files
             "      -T PREFIX\n"
-            "               Write tempory files to PREFIX.nnnn.bam\n"
+            "               Write temporary files to PREFIX.nnnn.bam\n"
             "      --no-PG  do not add a PG line\n",
             reads_store, DEF_CLEVEL, n_files);
 

--- a/samtools/bamshuf.c.pysam.c
+++ b/samtools/bamshuf.c.pysam.c
@@ -539,7 +539,7 @@ static int usage(FILE *fp, int n_files, int reads_store) {
             "      -l INT   Compression level [%d]\n" // DEF_CLEVEL
             "      -n INT   Number of temporary files [%d]\n" // n_files
             "      -T PREFIX\n"
-            "               Write tempory files to PREFIX.nnnn.bam\n"
+            "               Write temporary files to PREFIX.nnnn.bam\n"
             "      --no-PG  do not add a PG line\n",
             reads_store, DEF_CLEVEL, n_files);
 


### PR DESCRIPTION
This patch addresses a couple of typos caught by lintian while working on the packaging of pysam for Debian.