### PR TITLE
Fix multiarch macOS build by removing brewed liblzma

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,15 +10,13 @@ jobs:
         os: [ubuntu, macos]
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         exclude:
-          # Run only the latest 3.x on macOS
+          # Run only the latest two 3.x versions on macOS
           - os: macos
             python-version: 3.7
           - os: macos
             python-version: 3.8
           - os: macos
             python-version: 3.9
-          - os: macos
-            python-version: 3.11
 
     steps:
       - name: Checkout pysam
@@ -32,11 +30,16 @@ jobs:
       - name: Install prerequisite Python libraries
         run:  pip install cython pytest pytest-pep8
 
-      - name: Install build prerequisites
+      - name: Install Linux build prerequisites
         if:   runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -q --no-install-recommends --no-install-suggests libcurl4-openssl-dev
+
+      - name: Update macOS build prerequisites
+        if:   runner.os == 'macOS'
+        run: |
+          brew unlink xz || true  # Remove brewed liblzma as it is not multiarch
 
       - name: Build (directly from checkout)
         run:  python setup.py build


### PR DESCRIPTION
Python 3.11 is now the first actions/setup-python Python built to target universal2 (i.e., x86_64/arm64 multiarch) on macOS. (I think in the past 3.9 and 3.10 were also built to target universal2 for a while — at least, ISTR seeing multiarch builds on earlier Python versions — but this was later reverted; see actions/python-versions#114.)

Brewed packages such as xz (which provides liblzma.dylib and liblzma.a) are built for only a single native architecture. This led to build and configure failures when the native-only liblzma.dylib was linked against by a multiarch compilation.

Work around this by unlinking the xz package so that this brewed library is not found by the linker, failing back to the system .tbd file instead. If later build steps use brewed commands that need this library, we may need to `brew link` it again later, but for now we get away without it.

This enables us to reinstate the Python 3.11 build on macOS. Fixes #1205.