### PR TITLE
Move Cython to build dependencies in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -684,7 +684,7 @@ metadata = {
     'classifiers': [_f for _f in classifiers.split("\n") if _f],
     'url': "https://github.com/pysam-developers/pysam",
     'packages': package_list,
-    'requires': ['cython (>=0.29.12)'],
+    'setup_requires': ['cython (>=0.29.12)'],
     'ext_modules': [CyExtension(**opts) for opts in modules],
     'cmdclass': {'build_ext': cy_build_ext, 'clean_ext': clean_ext, 'sdist': cythonize_sdist},
     'package_dir': package_dirs,


### PR DESCRIPTION
Hi!

This PR moves Cython from the `requires` key to the `setup_requires` key in `setup.py`. With the current requirement, `pysam` would require Cython to be installed on the target machine, even when installing from a wheel, where no Cython compilation is necessary. By moving Cython to the `setup_requires` field, it indicates Cython is needed to build the package, but not actually needed to import the package once it has been built.