### PR TITLE
fix: improve parsing performance

### DIFF
--- a/htslib/htslib/kseq.h
+++ b/htslib/htslib/kseq.h
@@ -110,8 +110,8 @@
 				} else break; \
 			} \
 			if (delimiter == KS_SEP_LINE) {  \
-				for (i = ks->begin; i < ks->end; ++i)  \
-					if (ks->buf[i] == '\n') break; \
+				unsigned char *sep = memchr(ks->buf + ks->begin, '\n', ks->end - ks->begin); \
+				i = sep != NULL ? sep - ks->buf : ks->end; \
 			} else if (delimiter > KS_SEP_MAX) { \
 				for (i = ks->begin; i < ks->end; ++i) \
 					if (ks->buf[i] == delimiter) break; \


### PR DESCRIPTION
An original fix was submitted by [@kloetz](https://github.com/kloetzl) to seqtk repo. Improves FASTA parsing to 2GB/s . 

See: 
- https://github.com/lh3/seqtk/pull/123
- https://twitter.com/kloetzl/status/1661679452479266818