### PR TITLE
Use relative cimports rather than luck

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, macos]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12.0-rc.1']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         exclude:
           # Run only the latest few 3.x versions on macOS
           - os: macos
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout pysam
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Checkout pysam
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
@@ -132,7 +132,7 @@ jobs:
 
     steps:
       - name: Checkout pysam
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout pysam
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.2
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Checkout pysam
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/pysam/libcutils.pyx
+++ b/pysam/libcutils.pyx
@@ -20,10 +20,10 @@ from libc.stdio cimport stdout as c_stdout
 from posix.fcntl cimport open as c_open, O_WRONLY
 from posix.unistd cimport SEEK_SET, SEEK_CUR, SEEK_END
 
-from libcsamtools cimport samtools_dispatch, samtools_set_stdout, samtools_set_stderr, \
+from .libcsamtools cimport samtools_dispatch, samtools_set_stdout, samtools_set_stderr, \
     samtools_close_stdout, samtools_close_stderr, samtools_set_stdout_fn
 
-from libcbcftools cimport bcftools_dispatch, bcftools_set_stdout, bcftools_set_stderr, \
+from .libcbcftools cimport bcftools_dispatch, bcftools_set_stdout, bcftools_set_stderr, \
     bcftools_close_stdout, bcftools_close_stderr, bcftools_set_stdout_fn
 
 #####################################################################


### PR DESCRIPTION
Fix 6½ year old incorrect `cimport` statements that accidentally depended on `get_pysam_version()`'s addition to `sys.path`.

Add a second test commit (which hardcodes a version number in place of the existing `get_pysam_version()` code) temporarily to do a full CI check on the change.

That succeeded (see 2d67777b1c2d80bef1753c66bb0c36e18f78a9dc and [run 6466884695](https://github.com/pysam-developers/pysam/actions/runs/6466884695)); replace it with some minor actions workflow updates, to test them.