### PR TITLE
Fix error text when array tag typecode is invalid

### DIFF
--- a/pysam/libcalignedsegment.pyx
+++ b/pysam/libcalignedsegment.pyx
@@ -382,7 +382,7 @@ cdef inline pack_tags(tags):
                     raise ValueError("unsupported type code '{}'".format(value.typecode))
 
             if typecode not in DATATYPE2FORMAT:
-                raise ValueError("invalid value type '{}' ({})".format(chr(typecode), array.typecode))
+                raise ValueError("invalid value type '{}' ({})".format(chr(typecode), typecode))
 
             # use array.tostring() to retrieve byte representation and
             # save as bytes


### PR DESCRIPTION
In current master when, [this line](https://github.com/pysam-developers/pysam/blob/v0.22.0/pysam/libcalignedsegment.pyx#L385) is hit it raises an error reporting: `AttributeError: module 'array' has no attribute 'typecode'`. This is due to an apparent bug in the formatting of the intended error text. In order to report the valid error text this should be resolved. I believe the intent here is to report the typecode ordinal value (with the character provided earlier), but this the intent may have been to report the `value.typecode` in this error text. I can revert that in this PR if that is indeed the intent. 