### PR TITLE
Add ``htslib/hts_probe_cc.sh`` to sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -41,7 +41,7 @@ recursive-include htslib *.[ch]
 exclude htslib/*config*.h
 
 include htslib/configure.ac htslib/m4/*.m4 htslib/*.in
-include htslib/configure htslib/version.sh
+include htslib/configure htslib/hts_probe_cc.sh htslib/version.sh
 include htslib/Makefile htslib/*.mk
 exclude htslib/config.mk htslib/htscodecs.mk
 


### PR DESCRIPTION
Otherwise the `before-build` command `make -C {project}/htslib distclean` from `pyproject.toml` fail with:

```
      + sh -c 'make -C /project/htslib distclean'
  Makefile:142: htscodecs.mk: No such file or directory
  make: Entering directory `/project/htslib'
  echo '# Default htscodecs.mk generated by Makefile' > htscodecs.mk
  echo 'include $(HTSPREFIX)htscodecs_bundled.mk' >> htscodecs.mk
  ./hts_probe_cc.sh 'gcc' '-g -Wall -O2 -fvisibility=hidden ' '-fvisibility=hidden' >> htscodecs.mk
  /bin/sh: ./hts_probe_cc.sh: No such file or directory
  make: *** [htscodecs.mk] Error 127
  make: Leaving directory `/project/htslib'
```