### PR TITLE
htslib: Fix mmap configure check for current compilers

### DIFF
--- a/htslib/config.h.in
+++ b/htslib/config.h.in
@@ -147,6 +147,9 @@
 # define _DARWIN_USE_64_BIT_INODE 1
 #endif
 
+/* Enable default extensions. */
+#undef _DEFAULT_SOURCE
+
 /* Number of bits in a file offset, on hosts where this is settable. */
 #undef _FILE_OFFSET_BITS
 

--- a/htslib/configure
+++ b/htslib/configure
@@ -3405,6 +3405,8 @@ fi
 # PTHREAD_MUTEX_RECURSIVE on some Linux distributions). Hence we set it to 600.
 
 # Define _XOPEN_SOURCE unless the user has already done so via $CPPFLAGS etc.
+# It is necessary to define _DEFAULT_SOURCE at the same time, otherwise
+# _XOPEN_SOURCE will suppress some declarations needed by AC_FUNC_MMAP.
 
 ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
@@ -3746,6 +3748,9 @@ if test "x$ac_cv_have_decl__XOPEN_SOURCE" = xyes; then :
 else
 
 $as_echo "#define _XOPEN_SOURCE 600" >>confdefs.h
+
+
+$as_echo "#define _DEFAULT_SOURCE 1" >>confdefs.h
 
 fi
 

--- a/htslib/configure.ac
+++ b/htslib/configure.ac
@@ -78,8 +78,11 @@ HTS_PROG_CC_WERROR(hts_late_cflags)
 # PTHREAD_MUTEX_RECURSIVE on some Linux distributions). Hence we set it to 600.
 
 # Define _XOPEN_SOURCE unless the user has already done so via $CPPFLAGS etc.
+# It is necessary to define _DEFAULT_SOURCE at the same time, otherwise
+# _XOPEN_SOURCE will suppress some declarations needed by AC_FUNC_MMAP.
 AC_CHECK_DECL([_XOPEN_SOURCE], [],
-  [AC_DEFINE([_XOPEN_SOURCE], [600], [Specify X/Open requirements])],
+  [AC_DEFINE([_XOPEN_SOURCE], [600], [Specify X/Open requirements])
+   AC_DEFINE([_DEFAULT_SOURCE], [1], [Enable default extensions.])],
   [])
 
 


### PR DESCRIPTION
It is necessary to define _DEFAULT_SOURCE along with _XOPEN_SOURCE, otherwise the configure check for mmap fails with compilers which do not support implicit function declarations because the check relies on the presence of the getpagesize function.

Downstream version of samtools/htslib#1711.