### PR TITLE
Add AlignedSegment.__repr__

### DIFF
--- a/pysam/libcalignedsegment.pyx
+++ b/pysam/libcalignedsegment.pyx
@@ -978,6 +978,9 @@ cdef class AlignedSegment:
                                    self.query_qualities,
                                    self.tags)))
 
+    def __repr__(self):
+        return f'<{type(self).__name__}({self.query_name!r}, flags={self.flag}={self.flag:#x}, ref={self.reference_name!r}, zpos={self.reference_start}, mapq={self.mapping_quality}, cigar={self.cigarstring!r}, ...)>'
+
     def __copy__(self):
         return makeAlignedSegment(self._delegate, self.header)
 


### PR DESCRIPTION
Before:
```
<pysam.libcalignedsegment.AlignedSegment object at 0x7fd74c3ae2c0>
```
After:
```
<AlignedSegment('name', flags=16, ref='chr1', pos=1170070, mapq=255, cigar='50M', ...)>
```

I’ve used pysam with this patch for a while and find it very valuable when looking at `AlignedSegment`s in a debugger or the REPL.

I’ve chosen to include only the (from my perspective) most important attributes so that the output doesn’t become too long, in particular when there’s a list with `AlignedSegment`s.

The angle brackets are supposed to convey that the string cannot be passed to `eval()` to recreate the object. I’d be fine with removing them.