### PR TITLE
+ document how to run bcftools commands from pysam

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -172,6 +172,25 @@ Note that this means that output from commands which produce output on
 stdout will not be available. The only solution is to run samtools
 commands through subprocess.
 
+=====================================
+Using bcftools commands within python
+=====================================
+
+Commands available in `bcftools <https://samtools.github.io/bcftools/>`_ are also available as simple
+function calls, but they are invoked slightly differently from `samtools <https://www.htslib.org>`_.
+Command line options are also provided as arguments. For
+example::
+
+   import pysam.bcftools as bcftools
+   bcftools.reheader("-s", "samples.txt", "-o", "out.vcf.gz", "in.vcf.gz", catch_stdout=False)
+
+corresponds to the command line::
+
+   bcftools reheader -s samples.txt -o out.vcf.gz in.vcf.gz
+
+If the ``catch_stdout=False`` option is not specified, then the output of the
+`bcftools <https://samtools.github.io/bcftools/>`_ command will be returned as a variable
+
 ================================
 Working with tabix-indexed files
 ================================


### PR DESCRIPTION
I recently had trouble running the `bcftools` commands within pysam.  I saw the ["Using samtools commands within python" ][0] section within the documentation and thought things would behave similarly. I didn't find it to be true.  I ended up finding the solution through [github issue 958][1].  

I thought it would be nice to have this `bcftools` feature more explicitly documented for future users.

Let me know if any additional changes are desired.

[0]: https://pysam.readthedocs.io/en/stable/usage.html#using-samtools-commands-within-python
[1]: https://github.com/pysam-developers/pysam/issues/958