### PR TITLE
Export samtools wrappers

### DIFF
--- a/pysam/__init__.py
+++ b/pysam/__init__.py
@@ -44,6 +44,7 @@ __all__ = (
     libcalignmentfile.__all__ +  # type: ignore
     libcalignedsegment.__all__ +  # type: ignore
     libcsamfile.__all__ +  # type: ignore
+    samtools.__all__ +  # type: ignore
     ["SamtoolsError"] +
     ["Pileup"]
 )

--- a/pysam/samtools.py
+++ b/pysam/samtools.py
@@ -65,6 +65,8 @@ _SAMTOOLS_DISPATCH = {
     "samples": ("samples", ()),
 }
 
+__all__ = list(_SAMTOOLS_DISPATCH.keys())
+
 
 def _wrap_command(
     dispatch: str,


### PR DESCRIPTION
`pysam` does not currently export the various wrapper functions in the `samtools` module, resulting in type-checking errors.

e.g.
```py
45: error: Module has no attribute "faidx"  [attr-defined]
```

I've followed the pattern implemented in the other modules, exporting attributes in a module-specific `__all__` declaration and then adding this list to the package's `__all__`. 

I believe this PR addresses the problem, but I'm unable to verify - when I install the updated package locally with `pip install -e`, `mypy` cannot find the type stubs for `pysam`. (As an aside - is there a `CONTRIBUTING` or other documentation for local install/testing?) 

Thanks!