### PR TITLE
Fix invalid-type message for creating header from dictionary

### DIFF
--- a/pysam/libcalignmentfile.pyx
+++ b/pysam/libcalignmentfile.pyx
@@ -302,7 +302,7 @@ cdef class AlignmentHeader(object):
                 data = header_dict[record]
                 if not isinstance(data, VALID_HEADER_TYPES[record]):
                     raise ValueError(
-                        "invalid type for record %s: %s, expected %s".format(
+                        "invalid type for record {}: {}, expected {}".format(
                             record, type(data), VALID_HEADER_TYPES[record]))
                 if isinstance(data, Mapping):
                     lines.append(build_header_line(data, record))


### PR DESCRIPTION
The message for the type error when creating a SAM header from a dictionary misses type names. The following MWE causes the error by passing a dictionary instead of a list of dictionaries under the **PG** tag in the SAM header:
```
import pysam

header = {"PG": {"ID": "my-tool"}}
output = pysam.AlignmentFile("test.sam", "w", header=header)
```
The current invalid-type error message:
```
ValueError: invalid type for record %s: %s, expected %s
```
The fixed error message:
```
ValueError: invalid type for record PG: <class 'dict'>, expected <class 'collections.abc.Sequence'>
```