### PR TITLE
Explicitly add enum members as global names

### DIFF
--- a/pysam/libcalignedsegment.pyx
+++ b/pysam/libcalignedsegment.pyx
@@ -3409,10 +3409,16 @@ cpdef enum SAM_FLAGS:
     FSUPPLEMENTARY = 2048
 
 
+# TODO Remove these and remove the enumerators from __all__
+globals().update(getattr(CIGAR_OPS, "__members__"))
+globals().update(getattr(SAM_FLAGS, "__members__"))
+
+
 __all__ = [
     "AlignedSegment",
     "PileupColumn",
     "PileupRead",
+    "CIGAR_OPS",
     "CMATCH",
     "CINS",
     "CDEL",
@@ -3423,6 +3429,7 @@ __all__ = [
     "CEQUAL",
     "CDIFF",
     "CBACK",
+    "SAM_FLAGS",
     "FPAIRED",
     "FPROPER_PAIR",
     "FUNMAP",


### PR DESCRIPTION
Cython 3.1.0, released last week, changed the way enums work:

> Named `cpdef enums` no longer copy their item names into the global module namespace. This was considered unhelpful for named enums which already live in their own class namespace. In cases where the old behaviour was desired, users can add the following backwards compatible command after their enum class definition: `globals().update(TheUserEnumClass.__members__)`. Anonymous enums still produce global item names, as before.

For upcoming patch releases, this PR restores the status quo of having both
`pysam.CIGAR_OPS.CMATCH` and `pysam.CMATCH` et al. It applies a (modified form of) the suggested fix. Fixes #1339.

In a future minor release, we will likely remove this shim and require Python code to use `pysam.CIGAR_OPS.CMATCH` et al, following the new Cython convention. This would mean removing as per the `TODO` comment and also removing the global names from _libcalignedsegment.pyi_.