### PR TITLE
Avoid string escaping for `str(SamtoolsError)`

### DIFF
--- a/pysam/utils.py
+++ b/pysam/utils.py
@@ -13,12 +13,7 @@ from pysam.libcutils import _pysam_dispatch
 class SamtoolsError(Exception):
     '''exception raised in case of an error incurred in the samtools
     library.'''
-
-    def __init__(self, value):
-        self.value = value
-
-    def __str__(self):
-        return repr(self.value)
+    pass
 
 
 class PysamDispatcher(object):


### PR DESCRIPTION
will fix #1344.