### PR TITLE
Add bespoke classes for accessing SEQ and QUAL

### DIFF
--- a/pysam/libcalignedsegment.pxd
+++ b/pysam/libcalignedsegment.pxd
@@ -31,6 +31,10 @@ from pysam.libcalignmentfile cimport AlignmentFile, AlignmentHeader
 ctypedef AlignmentFile AlignmentFile_t
 
 
+cdef class AlignedSegmentBases:
+    cdef bam1_t *_delegate
+
+
 cdef class _AlignedSegment_Cache:  # For internal use only
     cdef clear_query_sequences(self)
     cdef clear_query_qualities(self)
@@ -55,7 +59,7 @@ cdef class AlignedSegment:
     # caching of array properties for quick access
     cdef _AlignedSegment_Cache cache
 
-    cdef object unused1
+    cdef AlignedSegmentBases _query_bases
     cdef object unused2
     cdef object unused3
 


### PR DESCRIPTION
Inspired by the request in #1346, “Faster Single-Base Access for Long Reads”:—

Instead of accessing `SEQ` (and eventually `QUAL`) via a `str` property, add classes that implement `__getitem__`, `__str__`, etc directly from the internal BAM representation. These classes can then be used to access subsequences and do other useful things that you would do with a `str`:

```
aln.query_bases[4]
aln.query_bases[3:12]
print(f"Sequence is {aln.query_bases}")
…etc…
```

without decoding the unrequested parts of the sequence data.

This demonstrates the idea. We will likely rename this and position it to become the principal way to access SEQ, deprecating `query_sequence`, and similarly for base qualities.