### PR TITLE
Support value_type of 'B' in get_tag_typecode()

### DIFF
--- a/pysam/libcalignedsegment.pyx
+++ b/pysam/libcalignedsegment.pyx
@@ -241,7 +241,7 @@ cdef inline uint8_t get_tag_typecode(value, value_type=None):
                 isinstance(value, tuple):
             typecode = b'B'
     else:
-        if value_type in 'aAsSIcCZidfH':
+        if value_type in 'aABsSIcCZidfH':
             typecode = force_bytes(value_type)[0]
 
     return typecode


### PR DESCRIPTION
# Context

If a user calls `set_tag(tag, value, value_type)` where `value_type='B'`, then the following error is raised:

```
ValueError('unsupported value_type {} in set_option'.format(typecode))
```

This corresponds to issue #1108.

---------------

# Bug

[Line 2512](https://github.com/pysam-developers/pysam/blob/2f9d50dde8eea7ddcdb643dcde0a088380f4549a/pysam/libcalignedsegment.pyx#L2512) of libcalignedsegment.pyx in the `set_tag()` function calls `get_tag_typecode(value, value_type)`.

In its current implementation, `get_tag_typecode` will always return a value of 0 (indicating an unknown type) if `value_type` is `'B'` due to `'B'` missing from the enumerated types:

https://github.com/pysam-developers/pysam/blob/2f9d50dde8eea7ddcdb643dcde0a088380f4549a/pysam/libcalignedsegment.pyx#L244-L245

Back in `set_tag()`, this typecode value of 0 triggers the ValueError.

-------------------

# Solution

Add `'B'` to the enumerated types in `get_tag_typecode()`.