### PR TITLE
AlignedSegment.set_tag(): validate Hex values for tag type 'H'

### DIFF
--- a/pysam/libcalignedsegment.pyx
+++ b/pysam/libcalignedsegment.pyx
@@ -2524,7 +2524,7 @@ cdef class AlignedSegment:
             # validate Hex values
             if not HEX_VALUE_REGEX.fullmatch(value):
                 raise ValueError(
-                    f"Invalid value {value} for tag {tag.decode()} with value_type 'H':
+                    f"Invalid value {value} for tag {tag.decode()} with value_type 'H': "
                     f"must match the regular expression {HEX_VALUE_REGEX.pattern}"
                 )
             # Note that hex tags are stored the very same


### PR DESCRIPTION
Added validation for values in Hex format tags, using regular expression defined in the SAM specification.

---------

Currently, `set_tag()` does not perform any validation of the tag value for Hex format tags (where `value_type` (`typecode`) is `'H'`). This means that `pysam` allows writing reads to a SAM/BAM file that may result in errors when trying to read that same read via `pysam.AlignmentFile.fetch()`.

Specifically, `pysam.AlignmentFile.fetch()` (via ... via `pysam.AlignmentFile.cnext()` via `sam.c:sam_read1()` via ... via  `sam.c:aux_parse()` in htslib) checks that Hex format tag values contain an even number of characters.

https://github.com/pysam-developers/pysam/blob/2f9d50dde8eea7ddcdb643dcde0a088380f4549a/htslib/sam.c#L2835-L2839

Therefore, the proposed patch (which follows the SAM specification) for the _write_ side of the  `pysam` interface will be a bit stricter than what the _read_ side checks for. Nonetheless, this helps ensure round-trip compatibility of reads written by pysam.