### PR TITLE
Fix silent truncation in IteratorRowAllRefs on I/O errors

### DIFF
--- a/pysam/libcalignmentfile.pyx
+++ b/pysam/libcalignmentfile.pyx
@@ -2256,8 +2256,15 @@ cdef class IteratorRowAllRefs(IteratorRow):
             self.rowiter.cnext()
 
             # If current iterator is not exhausted, return aligned read
-            if self.rowiter.retval > 0:
+            if self.rowiter.retval >= 0:
                 return makeAlignedSegment(self.rowiter.b, self.header)
+
+            if self.rowiter.retval == -2:
+                raise IOError('truncated file')
+            elif self.rowiter.retval < -1:
+                raise IOError(
+                    "error while reading file {}: {}".format(
+                        self.samfile.filename, self.rowiter.retval))
 
             self.tid += 1
 


### PR DESCRIPTION
## Summary

`IteratorRowAllRefs.__next__()` (used by `samfile.fetch()` without a region) only checked `retval > 0` to decide whether a record was available. All non-positive return values — including I/O errors (`retval < -1`) and truncated files (`retval == -2`) — were silently treated as end-of-reference, causing the iterator to advance to the next `tid`. On a read error mid-file, callers get `StopIteration` instead of an exception and have no indication that results are incomplete.

Every other iterator in pysam (`IteratorRowRegion`, `IteratorRowAll`, `IteratorRowHead`, `IteratorRowSelection`, `VariantFile`, etc.) already distinguishes EOF from error. `IteratorRowAllRefs` was the only one missing this check.

Add explicit error checks matching the pattern used by `IteratorRowRegion`: raise `IOError` on `retval < -1`, only treat `retval == -1` as normal end-of-reference.