### PR TITLE
Add missing NULL guard in PileupColumn.get_query_qualities

### DIFF
--- a/pysam/libcalignedsegment.pyx
+++ b/pysam/libcalignedsegment.pyx
@@ -3258,6 +3258,9 @@ cdef class PileupColumn:
 
         a list of quality scores : list
         """
+        if self.plp == NULL or self.plp[0] == NULL:
+            raise ValueError("PileupColumn accessed after iterator finished")
+
         cdef uint32_t x = 0
         cdef const bam_pileup1_t * p = NULL
         cdef uint32_t c = 0


### PR DESCRIPTION
## Summary

- Add the missing `plp == NULL` guard to `PileupColumn.get_query_qualities()` to match all 6 sibling methods (`pileups`, `get_num_aligned`, `get_query_sequences`, `get_mapping_qualities`, `get_query_positions`, `get_query_names`)
- Without this guard, calling `get_query_qualities()` after the pileup iterator is exhausted causes a segfault instead of raising a clean `ValueError`

## Test plan

- [ ] Run `REF_PATH=: pytest tests/AlignmentFilePileup_test.py -v`

---

**AI disclosure:** This PR was AI-assisted using Claude Code. The issue was identified via AI-guided code review, and the implementation was drafted by AI with human review and approval.