### PR TITLE
Fix TypeError in modified_bases_forward when query_sequence is None

### DIFF
--- a/pysam/libcalignedsegment.pyx
+++ b/pysam/libcalignedsegment.pyx
@@ -1939,12 +1939,9 @@ cdef class AlignedSegment:
             if pmods and self.is_reverse:                
                 rmod = {}
 
-                # Try to find the length of the original sequence
-                rlen = self.infer_read_length()
-                if rlen is None and self.query_sequence is None:
+                if self.query_sequence is None:
                     return rmod
-                else:
-                    rlen = len(self.query_sequence)
+                rlen = len(self.query_sequence)
                     
                 for k,mods in pmods.items():
                     nk = k[0],1 - k[1],k[2]


### PR DESCRIPTION
## Summary

- Fix a `TypeError` in the `modified_bases_forward` property when `query_sequence` is `None` but `infer_read_length()` returns a value
- The previous logic checked `rlen is None and self.query_sequence is None`, which meant when `infer_read_length()` returned a non-None value but `query_sequence` was still `None`, the code fell through to `len(self.query_sequence)` causing a `TypeError`
- The `infer_read_length()` result was never actually used — only `query_sequence` is needed for the coordinate transform, so the guard is simplified to check only `query_sequence`

## Test plan

- [ ] Run `REF_PATH=: pytest tests/AlignedSegment_test.py -v`

---

**AI disclosure:** This PR was AI-assisted using Claude Code. The issue was identified via AI-guided code review, and the implementation was drafted by AI with human review and approval.