### PR TITLE
Remove unused variables in AlignedSegment compare method

### DIFF
--- a/pysam/libcalignedsegment.pyx
+++ b/pysam/libcalignedsegment.pyx
@@ -1035,9 +1035,6 @@ cdef class AlignedSegment:
         if t == o:
             return 0
 
-        cdef uint8_t *a = <uint8_t*>&t.core
-        cdef uint8_t *b = <uint8_t*>&o.core
-
         retval = memcmp(&t.core, &o.core, sizeof(bam1_core_t))
         if retval:
             return retval


### PR DESCRIPTION
## Summary

- Remove unused `a` and `b` pointer variables in `AlignedSegment.__richcmp__` — the comparison uses `memcmp(&t.core, &o.core, ...)` directly

## Test plan

- [ ] Run `REF_PATH=: pytest tests/AlignedSegment_test.py -v`

---

**AI disclosure:** This PR was AI-assisted using Claude Code. The issue was identified via AI-guided code review, and the implementation was drafted by AI with human review and approval.