### PR TITLE
Disable Cython profiling hooks in production builds

### DIFF
--- a/pysam/libcalignedsegment.pyx
+++ b/pysam/libcalignedsegment.pyx
@@ -1,6 +1,6 @@
 # cython: language_level=3
 # cython: embedsignature=True
-# cython: profile=True
+# cython: profile=False
 ###############################################################################
 ###############################################################################
 # Cython wrapper for SAM/BAM/CRAM files based on htslib

--- a/pysam/libcalignmentfile.pyx
+++ b/pysam/libcalignmentfile.pyx
@@ -1,5 +1,5 @@
 # cython: embedsignature=True
-# cython: profile=True
+# cython: profile=False
 ########################################################
 ########################################################
 # Cython wrapper for SAM/BAM/CRAM files based on htslib

--- a/pysam/libcbcf.pyx
+++ b/pysam/libcbcf.pyx
@@ -1,6 +1,6 @@
 # cython: language_level=3
 # cython: embedsignature=True
-# cython: profile=True
+# cython: profile=False
 ###############################################################################
 ###############################################################################
 ## Cython wrapper for htslib VCF/BCF reader/writer

--- a/pysam/libcfaidx.pyx
+++ b/pysam/libcfaidx.pyx
@@ -1,5 +1,5 @@
 # cython: embedsignature=True
-# cython: profile=True
+# cython: profile=False
 ###############################################################################
 ###############################################################################
 # Cython wrapper for SAM/BAM/CRAM files based on htslib

--- a/pysam/libchtslib.pyx
+++ b/pysam/libchtslib.pyx
@@ -1,6 +1,6 @@
 # cython: language_level=3
 # cython: embedsignature=True
-# cython: profile=True
+# cython: profile=False
 # adds doc-strings for sphinx
 
 ########################################################################

--- a/pysam/libcsamfile.pyx
+++ b/pysam/libcsamfile.pyx
@@ -1,5 +1,5 @@
 # cython: embedsignature=True
-# cython: profile=True
+# cython: profile=False
 # adds doc-strings for sphinx
 import tempfile
 import os

--- a/pysam/libctabix.pyx
+++ b/pysam/libctabix.pyx
@@ -1,6 +1,6 @@
 # cython: language_level=3
 # cython: embedsignature=True
-# cython: profile=True
+# cython: profile=False
 ###############################################################################
 ###############################################################################
 # Cython wrapper for access to tabix indexed files in bgzf format


### PR DESCRIPTION
## Summary

- Change `# cython: profile=True` to `# cython: profile=False` in all 7 `.pyx` files
- The profiling hooks add overhead to every function call (10-30%) and should not be enabled in production builds

## Test plan

- [ ] Run full test suite: `REF_PATH=: pytest`

---

**AI disclosure:** This PR was AI-assisted using Claude Code. The issue was identified via AI-guided code review, and the implementation was drafted by AI with human review and approval.