### PR TITLE
Remove redundant copy in getSequenceInRange

### DIFF
--- a/pysam/libcalignedsegment.pyx
+++ b/pysam/libcalignedsegment.pyx
@@ -550,7 +550,7 @@ cdef inline bytes getSequenceInRange(bam1_t *src,
         # note: do not use string literal as it will be a python string
         s[k-start] = seq_nt16_str[p[k//2] >> 4 * (1 - k%2) & 0xf]
 
-    return charptr_to_bytes(seq)
+    return seq
 
 
 #####################################################################


### PR DESCRIPTION
## Summary

- Remove a redundant copy in `getSequenceInRange` where `charptr_to_bytes(seq)` was called on `seq` which is already a Python `bytes` object created by `PyBytes_FromStringAndSize`
- The `charptr_to_bytes` call was converting `bytes → const char* → bytes`, creating an unnecessary copy

## Test plan

- [ ] Run `REF_PATH=: pytest tests/AlignedSegment_test.py -v`

---

**AI disclosure:** This PR was AI-assisted using Claude Code. The issue was identified via AI-guided code review, and the implementation was drafted by AI with human review and approval.