### PR TITLE
Cache complement translation table in get_forward_sequence

### DIFF
--- a/pysam/libcalignedsegment.pyx
+++ b/pysam/libcalignedsegment.pyx
@@ -86,6 +86,8 @@ cdef int NCIGAR_CODES = 10
 CIGAR2CODE = dict([y, x] for x, y in enumerate(CODE2CIGAR))
 CIGAR_REGEX = re.compile("(\d+)([MIDNSHP=XB])")
 
+COMPLEMENT_TABLE = str.maketrans("ACGTacgtNnXx", "TGCAtgcaNnXx")
+
 # names for keys in dictionary representation of an AlignedSegment
 KEY_NAMES = ["name", "flag", "ref_name", "ref_pos", "map_quality", "cigar",
              "next_ref_name", "next_ref_pos", "length", "seq", "qual", "tags"]
@@ -2072,7 +2074,7 @@ cdef class AlignedSegment:
             return None
         s = force_str(self.query_sequence)
         if self.is_reverse:
-            s = s.translate(str.maketrans("ACGTacgtNnXx", "TGCAtgcaNnXx"))[::-1]
+            s = s.translate(COMPLEMENT_TABLE)[::-1]
         return s
 
     def get_forward_qualities(self):


### PR DESCRIPTION
## Summary

- Move the `str.maketrans("ACGTacgtNnXx", "TGCAtgcaNnXx")` call from inside `get_forward_sequence()` to a module-level `COMPLEMENT_TABLE` constant
- Previously the translation table was rebuilt on every invocation

## Test plan

- [ ] Run `REF_PATH=: pytest tests/AlignedSegment_test.py -v -k forward`

---

**AI disclosure:** This PR was AI-assisted using Claude Code. The issue was identified via AI-guided code review, and the implementation was drafted by AI with human review and approval.