### PR TITLE
Extract shared PileupColumn validity check

### DIFF
--- a/pysam/libcalignedsegment.pxd
+++ b/pysam/libcalignedsegment.pxd
@@ -85,6 +85,7 @@ cdef class PileupColumn:
     cdef uint32_t min_base_quality
     cdef kstring_t buf
     cdef char * reference_sequence
+    cdef _check_pileup_valid(self)
 
 cdef class PileupRead:
     cdef int32_t  _qpos

--- a/pysam/libcalignedsegment.pyx
+++ b/pysam/libcalignedsegment.pyx
@@ -3041,11 +3041,14 @@ cdef class PileupColumn:
         def __get__(self):
             return self.pos
 
+    cdef _check_pileup_valid(self):
+        if self.plp == NULL or self.plp[0] == NULL:
+            raise ValueError("PileupColumn accessed after iterator finished")
+
     property pileups:
         '''list of reads (:class:`pysam.PileupRead`) aligned to this column'''
         def __get__(self):
-            if self.plp == NULL or self.plp[0] == NULL:
-                raise ValueError("PileupColumn accessed after iterator finished")
+            self._check_pileup_valid()
 
             cdef int x
             cdef const bam_pileup1_t * p = NULL
@@ -3097,12 +3100,11 @@ cdef class PileupColumn:
         :meth:`get_mapping_qualities`, etc.
 
         """
+        self._check_pileup_valid()
         cdef uint32_t x = 0
         cdef uint32_t c = 0
         cdef uint32_t cnt = 0
         cdef const bam_pileup1_t * p = NULL
-        if self.plp == NULL or self.plp[0] == NULL:
-            raise ValueError("PileupColumn accessed after iterator finished")
 
         for x from 0 <= x < self.n_pu:
             p = &(self.plp[0][x])
@@ -3170,6 +3172,7 @@ cdef class PileupColumn:
         a list of bases/sequences per read at pileup column position. : list
 
         """
+        self._check_pileup_valid()
         cdef uint32_t x = 0
         cdef uint32_t j = 0
         cdef uint32_t c = 0
@@ -3177,9 +3180,6 @@ cdef class PileupColumn:
         cdef uint8_t rb = 0
         cdef kstring_t * buf = &self.buf
         cdef const bam_pileup1_t * p = NULL
-
-        if self.plp == NULL or self.plp[0] == NULL:
-            raise ValueError("PileupColumn accessed after iterator finished")
 
         buf.l = 0
 
@@ -3258,6 +3258,7 @@ cdef class PileupColumn:
 
         a list of quality scores : list
         """
+        self._check_pileup_valid()
         cdef uint32_t x = 0
         cdef const bam_pileup1_t * p = NULL
         cdef uint32_t c = 0
@@ -3286,9 +3287,7 @@ cdef class PileupColumn:
 
         a list of quality scores : list
         """
-        if self.plp == NULL or self.plp[0] == NULL:
-            raise ValueError("PileupColumn accessed after iterator finished")
-
+        self._check_pileup_valid()
         cdef uint32_t x = 0
         cdef const bam_pileup1_t * p = NULL
         result = []
@@ -3312,9 +3311,7 @@ cdef class PileupColumn:
 
         a list of read positions : list
         """
-        if self.plp == NULL or self.plp[0] == NULL:
-            raise ValueError("PileupColumn accessed after iterator finished")
-
+        self._check_pileup_valid()
         cdef uint32_t x = 0
         cdef const bam_pileup1_t * p = NULL
         result = []
@@ -3338,9 +3335,7 @@ cdef class PileupColumn:
 
         a list of query names at pileup column position. : list
         """
-        if self.plp == NULL or self.plp[0] == NULL:
-            raise ValueError("PileupColumn accessed after iterator finished")
-
+        self._check_pileup_valid()
         cdef uint32_t x = 0
         cdef const bam_pileup1_t * p = NULL
         result = []


### PR DESCRIPTION
## Summary

- Extract a `_check_pileup_valid()` cdef helper on `PileupColumn` that raises `ValueError` if the pileup buffer is NULL (iterator exhausted)
- All 7 public PileupColumn methods now call this helper instead of inlining the guard check
- Also adds the previously missing guard to `get_query_qualities()` (fixing the same bug as PR #1380 but structurally)

## Test plan

- [ ] Run `REF_PATH=: pytest tests/AlignmentFilePileup_test.py -v`

---

**AI disclosure:** This PR was AI-assisted using Claude Code. The issue was identified via AI-guided code review, and the implementation was drafted by AI with human review and approval.