### PR TITLE
cram seek support

### DIFF
--- a/pysam/libchtslib.pyx
+++ b/pysam/libchtslib.pyx
@@ -499,7 +499,7 @@ cdef class HTSFile(object):
             ret = 0 if (hseek(self.htsfile.fp.hfile, offset, whence) >= 0) else -1
         elif fmt.format == cram:
             with nogil:
-                ret = cram_seek(hts_get_bgzfp(self.htsfile), offset, whence)
+                ret = cram_seek(self.htsfile.fp.cram, offset, whence)
         else:
             raise NotImplementedError(f"seek not implemented in files compressed by method {fmt.compression}")
         return ret


### PR DESCRIPTION
there is cram support for tell, just added cram support for seek. 

without this, pysam raises issue `seek not implemented in files compressed by method 3` when seek is performed on cram files.

this has been proposed a while ago #1034

`cram_seek` expects fd, so it should work as is instead of providing fp directly via `cram_seek(hts_get_bgzfp(self.htsfile)`