### PR TITLE
Accept file-like objects in `VariantFile` filename parameter

### DIFF
--- a/pysam/libcbcf.pyi
+++ b/pysam/libcbcf.pyi
@@ -1,8 +1,8 @@
-import sys
 from typing import (
     Optional,
     Union,
     Any,
+    IO,
     Sequence,
     Tuple,
     Iterator,
@@ -321,7 +321,7 @@ class VariantFile(HTSFile):
     def header_written(self) -> bool: ...
     def __init__(
         self,
-        filename: StrOrBytesPath,
+        filename: Union[StrOrBytesPath, IO[Any]],
         mode: Optional[str] = ...,
         index_filename: Optional[str] = ...,
         header: Optional[VariantHeader] = ...,
@@ -336,7 +336,7 @@ class VariantFile(HTSFile):
     def copy(self) -> VariantFile: ...
     def open(
         self,
-        filename: StrOrBytesPath,
+        filename: Union[StrOrBytesPath, IO[Any]],
         mode: Optional[str] = ...,
         index_filename: Optional[str] = ...,
         header: Optional[VariantHeader] = ...,


### PR DESCRIPTION
The `VariantFile.__init__` and `VariantFile.open` stubs typed `filename` as `StrOrBytesPath`. This excluded file-like objects like `TextIO` and `BinaryIO`, but the underlying implementation supports them. When `filename` is not a path, `open()` catches the `TypeError` from `encode_filename`, then `_open_htsfile()` calls `.fileno()` on it to obtain a file descriptor that is passed to htslib's `hdopen`/`hts_hopen`. Consequently, any object with a `.fileno()` method is valid.
